### PR TITLE
First corrections for multi-line examples

### DIFF
--- a/docs/commands/Add-AssertionOperator.mdx
+++ b/docs/commands/Add-AssertionOperator.mdx
@@ -29,7 +29,6 @@ This function allows you to create custom Should assertions.
 ### EXAMPLE 1
 ```powershell
 function BeAwesome($ActualValue, [switch] $Negate) {
-```
 
 \[bool\] $succeeded = $ActualValue -eq 'Awesome'
 	if ($Negate) { $succeeded = -not $succeeded }
@@ -59,6 +58,8 @@ Add-AssertionOperator -Name  BeAwesome `
 PS C:\\\> "bad" | should -BeAwesome
 
 {bad} is not Awesome
+```
+
 
 ## PARAMETERS
 

--- a/docs/commands/Assert-MockCalled.mdx
+++ b/docs/commands/Assert-MockCalled.mdx
@@ -40,55 +40,58 @@ passed to Assert-MockCalled, Assert-MockCalled will throw an exception.
 ### EXAMPLE 1
 ```powershell
 Mock Set-Content {}
-```
 
 {...
 Some Code ...}
 
 C:\PS\>Assert-MockCalled Set-Content
 
+```
+
 This will throw an exception and cause the test to fail if Set-Content is not called in Some Code.
 
 ### EXAMPLE 2
 ```powershell
 Mock Set-Content -parameterFilter {$path.StartsWith("$env:temp\")}
-```
 
 {...
 Some Code ...}
 
 C:\PS\>Assert-MockCalled Set-Content 2 { $path -eq "$env:temp\test.txt" }
 
+```
+
 This will throw an exception if some code calls Set-Content on $path=$env:temp\test.txt less than 2 times
 
 ### EXAMPLE 3
 ```powershell
 Mock Set-Content {}
-```
 
 {...
 Some Code ...}
 
 C:\PS\>Assert-MockCalled Set-Content 0
 
+```
+
 This will throw an exception if some code calls Set-Content at all
 
 ### EXAMPLE 4
 ```powershell
 Mock Set-Content {}
-```
 
 {...
 Some Code ...}
 
 C:\PS\>Assert-MockCalled Set-Content -Exactly 2
 
+```
+
 This will throw an exception if some code does not call Set-Content Exactly two times.
 
 ### EXAMPLE 5
 ```powershell
 Describe 'Assert-MockCalled Scope behavior' {
-```
 
 Mock Set-Content { }
 
@@ -100,12 +103,13 @@ Some Code ...}
     }
 }
 
+```
+
 Checks for calls only within the current It block.
 
 ### EXAMPLE 6
 ```powershell
 Describe 'Describe' {
-```
 
 Mock -ModuleName SomeModule Set-Content { }
 
@@ -117,6 +121,8 @@ Some Code ...}
     }
 }
 
+```
+
 Checks for calls to the mock within the SomeModule module. 
 Note that both the Mock
 and Assert-MockCalled commands use the same module name.
@@ -124,11 +130,14 @@ and Assert-MockCalled commands use the same module name.
 ### EXAMPLE 7
 ```powershell
 Assert-MockCalled Get-ChildItem -ExclusiveFilter { $Path -eq 'C:\' }
+
 ```
 
 Checks to make sure that Get-ChildItem was called at least one time with
 the -Path parameter set to 'C:\', and that it was not called at all with
 the -Path parameter set to any other value.
+
+
 
 ## PARAMETERS
 

--- a/docs/commands/Assert-VerifiableMock.mdx
+++ b/docs/commands/Assert-VerifiableMock.mdx
@@ -37,25 +37,29 @@ have not been invoked, an exception will be thrown.
 ### EXAMPLE 1
 ```powershell
 Mock Set-Content {} -Verifiable -ParameterFilter {$Path -eq "some_path" -and $Value -eq "Expected Value"}
-```
 
 { ...some code that never calls Set-Content some_path -Value "Expected Value"...
 }
 
 Assert-VerifiableMock
 
+```
+
 This will throw an exception and cause the test to fail.
 
 ### EXAMPLE 2
 ```powershell
 Mock Set-Content {} -Verifiable -ParameterFilter {$Path -eq "some_path" -and $Value -eq "Expected Value"}
-```
 
 Set-Content some_path -Value "Expected Value"
 
 Assert-VerifiableMock
 
+```
+
 This will not throw an exception because the mock was invoked.
+
+
 
 ## PARAMETERS
 

--- a/docs/commands/Context.mdx
+++ b/docs/commands/Context.mdx
@@ -33,7 +33,6 @@ apply to tests within that Context .
 ### EXAMPLE 1
 ```powershell
 function Add-Numbers($a, $b) {
-```
 
 return $a + $b
 }
@@ -54,6 +53,8 @@ Describe "Add-Numbers" {
 }
 	}
 }
+```
+
 
 ## PARAMETERS
 

--- a/docs/commands/Describe.mdx
+++ b/docs/commands/Describe.mdx
@@ -33,7 +33,6 @@ block may contain any number of Context and It blocks.
 ### EXAMPLE 1
 ```powershell
 function Add-Numbers($a, $b) {
-```
 
 return $a + $b
 }
@@ -59,6 +58,8 @@ Describe "Add-Numbers" {
         $sum | Should -Be "twothree"
     }
 }
+```
+
 
 ## PARAMETERS
 

--- a/docs/commands/Find-GherkinStep.mdx
+++ b/docs/commands/Find-GherkinStep.mdx
@@ -29,11 +29,13 @@ Returns the step(s) that match
 ### EXAMPLE 1
 ```powershell
 Find-GherkinStep -Step 'And the module is imported'
-```
 
 Step                       Source                      Implementation
 ----                       ------                      --------------
+
 And the module is imported .\module.Steps.ps1: line 39 ...
+```
+
 
 ## PARAMETERS
 

--- a/docs/commands/Get-ShouldOperator.mdx
+++ b/docs/commands/Get-ShouldOperator.mdx
@@ -32,6 +32,7 @@ including any registered by the user with Add-AssertionOperator.
 ### EXAMPLE 1
 ```powershell
 Get-ShouldOperator
+
 ```
 
 Return all available Should assertion operators and their aliases.
@@ -39,10 +40,11 @@ Return all available Should assertion operators and their aliases.
 ### EXAMPLE 2
 ```powershell
 Get-ShouldOperator -Name Be
-```
 
 Return help examples for the Be assertion operator.
 -Name is a dynamic parameter that tab completes all available options.
+```
+
 
 ## PARAMETERS
 

--- a/docs/commands/Get-TestDriveItem.mdx
+++ b/docs/commands/Get-TestDriveItem.mdx
@@ -35,10 +35,13 @@ and will be deleted in the next major version of Pester.
 ### EXAMPLE 1
 ```powershell
 Get-TestDriveItem MyTestFolder\MyTestFile.txt
+
 ```
 
 This command returns the file MyTestFile.txt located in the folder MyTestFolder
 what is located under TestDrive.
+
+
 
 ## PARAMETERS
 

--- a/docs/commands/GherkinStep.mdx
+++ b/docs/commands/GherkinStep.mdx
@@ -32,10 +32,7 @@ executed in a manner that is similar to unit tests.
 
 ### EXAMPLE 1
 ```powershell
-# Gherkin Steps need to be placed in a *.Step.ps1 file
-```
 
-# filename: copyfile.Step.ps1
 Given 'we have a destination folder' {
     mkdir testdrive:\target -ErrorAction SilentlyContinue
     'testdrive:\target' | Should Exist
@@ -49,8 +46,6 @@ Then 'we have a new file in the destination' {
     'testdrive:\target\something.txt' | Should Exist
 }
 
-# Steps need to allign with feature specifications in a *.feature file
-# filename: copyfile.feature
 Feature: You can copy one file
 
 Scenario: The file exists, and the target folder exists
@@ -59,25 +54,24 @@ Scenario: The file exists, and the target folder exists
     When we call Copy-Item
     Then we have a new file in the destination
     And the new file is the same as the original file
-
+```
 ### EXAMPLE 2
 ```powershell
-# This example shows a complex regex match that can be used for multiple lines in the feature specification
-```
 
-# filename: namedregex.Step.ps1
+
 Given 'we have a (?\<name\>\S*) function' {
     param($name)
     "$psscriptroot\..\MyModule\*\$name.ps1" | Should Exist
 }
 
-# filename: namedregex.feature
 Scenario: basic feature support
     Given we have public functions
     And we have a New-Node function
     And we have a New-Edge function
     And we have a New-Graph function
     And we have a New-Subgraph function
+```
+
 
 ## PARAMETERS
 

--- a/docs/commands/InModuleScope.mdx
+++ b/docs/commands/InModuleScope.mdx
@@ -35,7 +35,6 @@ either inside or outside a Describe block.
 ### EXAMPLE 1
 ```powershell
 # The script module:
-```
 
 function PublicFunction
 {
@@ -49,6 +48,8 @@ function PrivateFunction
 
 Export-ModuleMember -Function PublicFunction
 
+# The test script:
+
 Import-Module MyModule
 
 InModuleScope MyModule {
@@ -58,11 +59,11 @@ InModuleScope MyModule {
         }
     }
 }
+```
 
 Normally you would not be able to access "PrivateFunction" from
 the PowerShell session, because the module only exported
-"PublicFunction". 
-Using InModuleScope allowed this call to
+"PublicFunction". Using InModuleScope allowed this call to
 "PrivateFunction" to work successfully.
 
 ## PARAMETERS

--- a/docs/commands/Invoke-Gherkin.mdx
+++ b/docs/commands/Invoke-Gherkin.mdx
@@ -43,6 +43,7 @@ Optionally, Pester can generate a report of how much code is covered by the test
 ### EXAMPLE 1
 ```powershell
 Invoke-Gherkin
+
 ```
 
 This will find all *.feature specifications and execute their tests.
@@ -51,6 +52,7 @@ No exit code will be returned and no log file will be saved.
 ### EXAMPLE 2
 ```powershell
 Invoke-Gherkin -Path ./tests/Utils*
+
 ```
 
 This will run all *.feature specifications under ./Tests that begin with Utils.
@@ -58,6 +60,7 @@ This will run all *.feature specifications under ./Tests that begin with Utils.
 ### EXAMPLE 3
 ```powershell
 Invoke-Gherkin -ScenarioName "Add Numbers"
+
 ```
 
 This will only run the Scenario named "Add Numbers"
@@ -65,6 +68,7 @@ This will only run the Scenario named "Add Numbers"
 ### EXAMPLE 4
 ```powershell
 Invoke-Gherkin -EnableExit -OutputXml "./artifacts/TestResults.xml"
+
 ```
 
 This runs all tests from the current directory downwards and writes the results according to the NUnit schema to artifacts/TestResults.xml just below the current directory.
@@ -73,6 +77,7 @@ The test run will return an exit code equal to the number of test failures.
 ### EXAMPLE 5
 ```powershell
 Invoke-Gherkin -CodeCoverage 'ScriptUnderTest.ps1'
+
 ```
 
 Runs all *.feature specifications in the current directory, and generates a coverage report for all commands in the "ScriptUnderTest.ps1" file.
@@ -80,6 +85,7 @@ Runs all *.feature specifications in the current directory, and generates a cove
 ### EXAMPLE 6
 ```powershell
 Invoke-Gherkin -CodeCoverage @{ Path = 'ScriptUnderTest.ps1'; Function = 'FunctionUnderTest' }
+
 ```
 
 Runs all *.feature specifications in the current directory, and generates a coverage report for all commands in the "FunctionUnderTest" function in the "ScriptUnderTest.ps1" file.
@@ -87,9 +93,12 @@ Runs all *.feature specifications in the current directory, and generates a cove
 ### EXAMPLE 7
 ```powershell
 Invoke-Gherkin -CodeCoverage @{ Path = 'ScriptUnderTest.ps1'; StartLine = 10; EndLine = 20 }
+
 ```
 
 Runs all *.feature specifications in the current directory, and generates a coverage report for all commands on lines 10 through 20 in the "ScriptUnderTest.ps1" file.
+
+
 
 ## PARAMETERS
 

--- a/docs/commands/Invoke-Pester.mdx
+++ b/docs/commands/Invoke-Pester.mdx
@@ -77,6 +77,7 @@ repository, see https://github.com/Pester.
 ### EXAMPLE 1
 ```powershell
 Invoke-Pester
+
 ```
 
 This command runs all *.Tests.ps1 files in the current directory and its subdirectories.
@@ -84,6 +85,7 @@ This command runs all *.Tests.ps1 files in the current directory and its subdire
 ### EXAMPLE 2
 ```powershell
 Invoke-Pester -Script .\Util*
+
 ```
 
 This commands runs all *.Tests.ps1 files in subdirectories with names that begin
@@ -92,6 +94,7 @@ with 'Util' and their subdirectories.
 ### EXAMPLE 3
 ```powershell
 Invoke-Pester -Script D:\MyModule, @{ Path = '.\Tests\Utility\ModuleUnit.Tests.ps1'; Parameters = @{ Name = 'User01' }; Arguments = srvNano16  }
+
 ```
 
 This command runs all *.Tests.ps1 files in D:\MyModule and its subdirectories.
@@ -101,6 +104,7 @@ parameters: .\Tests\Utility\ModuleUnit.Tests.ps1 srvNano16 -Name User01
 ### EXAMPLE 4
 ```powershell
 Invoke-Pester -Script @{Script = $scriptText}
+
 ```
 
 This command runs all tests passed as string in $scriptText variable with no aditional parameters and arguments.
@@ -112,6 +116,7 @@ This command can be used when tests and scripts are stored not on the FileSystem
 ### EXAMPLE 5
 ```powershell
 Invoke-Pester -TestName "Add Numbers"
+
 ```
 
 This command runs only the tests in the Describe block named "Add Numbers".
@@ -119,7 +124,6 @@ This command runs only the tests in the Describe block named "Add Numbers".
 ### EXAMPLE 6
 ```powershell
 $results = Invoke-Pester -Script D:\MyModule -PassThru -Show None
-```
 
 $failed = $results.TestResult | where Result -eq 'Failed'
 
@@ -159,6 +163,8 @@ The third command gets the names of the failing results.
 The result name is the
 name of the It block that contains the test.
 
+```
+
 The fourth command uses an array index to get the first failing result.
 The
 property values describe the test, the expected result, the actual result, and
@@ -167,6 +173,7 @@ useful values, including a stack trace.
 ### EXAMPLE 7
 ```powershell
 Invoke-Pester -EnableExit -OutputFile ".\artifacts\TestResults.xml" -OutputFormat NUnitXml
+
 ```
 
 This command runs all tests in the current directory and its subdirectories.
@@ -178,6 +185,7 @@ test returns an exit code equal to the number of test failures.
 ### EXAMPLE 8
 ```powershell
 Invoke-Pester -CodeCoverage 'ScriptUnderTest.ps1'
+
 ```
 
 Runs all *.Tests.ps1 scripts in the current directory, and generates a coverage
@@ -186,6 +194,7 @@ report for all commands in the "ScriptUnderTest.ps1" file.
 ### EXAMPLE 9
 ```powershell
 Invoke-Pester -CodeCoverage @{ Path = 'ScriptUnderTest.ps1'; Function = 'FunctionUnderTest' }
+
 ```
 
 Runs all *.Tests.ps1 scripts in the current directory, and generates a coverage
@@ -194,6 +203,7 @@ report for all commands in the "FunctionUnderTest" function in the "ScriptUnderT
 ### EXAMPLE 10
 ```powershell
 Invoke-Pester -CodeCoverage 'ScriptUnderTest.ps1' -CodeCoverageOutputFile '.\artifacts\TestOutput.xml'
+
 ```
 
 Runs all *.Tests.ps1 scripts in the current directory, and generates a coverage
@@ -203,6 +213,7 @@ file using the JaCoCo XML Report DTD.
 ### EXAMPLE 11
 ```powershell
 Invoke-Pester -CodeCoverage @{ Path = 'ScriptUnderTest.ps1'; StartLine = 10; EndLine = 20 }
+
 ```
 
 Runs all *.Tests.ps1 scripts in the current directory, and generates a coverage
@@ -211,12 +222,15 @@ report for all commands on lines 10 through 20 in the "ScriptUnderTest.ps1" file
 ### EXAMPLE 12
 ```powershell
 Invoke-Pester -Script C:\Tests -Tag UnitTest, Newest -ExcludeTag Bug
+
 ```
 
 This command runs *.Tests.ps1 files in C:\Tests and its subdirectories.
 In those
 files, it runs only tests that have UnitTest or Newest tags, unless the test
 also has a Bug tag.
+
+
 
 ## PARAMETERS
 

--- a/docs/commands/It.mdx
+++ b/docs/commands/It.mdx
@@ -54,7 +54,6 @@ command as the first tested statement in the It block.
 ### EXAMPLE 1
 ```powershell
 function Add-Numbers($a, $b) {
-```
 
 return $a + $b
 }
@@ -80,11 +79,10 @@ Describe "Add-Numbers" {
         $sum | Should -Be "twothree"
     }
 }
-
+```
 ### EXAMPLE 2
 ```powershell
 function Add-Numbers($a, $b) {
-```
 
 return $a + $b
 }
@@ -104,6 +102,8 @@ Describe "Add-Numbers" {
         $sum | Should -Be $expectedResult
     }
 }
+```
+
 
 ## PARAMETERS
 

--- a/docs/commands/Mock.mdx
+++ b/docs/commands/Mock.mdx
@@ -68,6 +68,7 @@ Each module's mock maintains a separate call history and verified status.
 ### EXAMPLE 1
 ```powershell
 Mock Get-ChildItem { return @{FullName = "A_File.TXT"} }
+
 ```
 
 Using this Mock, all calls to Get-ChildItem will return a hashtable with a
@@ -76,6 +77,7 @@ FullName property returning "A_File.TXT"
 ### EXAMPLE 2
 ```powershell
 Mock Get-ChildItem { return @{FullName = "A_File.TXT"} } -ParameterFilter { $Path -and $Path.StartsWith($env:temp) }
+
 ```
 
 This Mock will only be applied to Get-ChildItem calls within the user's temp directory.
@@ -83,6 +85,7 @@ This Mock will only be applied to Get-ChildItem calls within the user's temp dir
 ### EXAMPLE 3
 ```powershell
 Mock Set-Content {} -Verifiable -ParameterFilter { $Path -eq "some_path" -and $Value -eq "Expected Value" }
+
 ```
 
 When this mock is used, if the Mock is never invoked and Assert-VerifiableMock is called, an exception will be thrown.
@@ -91,10 +94,11 @@ The command behavior will do nothing since the ScriptBlock is empty.
 ### EXAMPLE 4
 ```powershell
 Mock Get-ChildItem { return @{FullName = "A_File.TXT"} } -ParameterFilter { $Path -and $Path.StartsWith($env:temp\1) }
-```
 
 Mock Get-ChildItem { return @{FullName = "B_File.TXT"} } -ParameterFilter { $Path -and $Path.StartsWith($env:temp\2) }
 Mock Get-ChildItem { return @{FullName = "C_File.TXT"} } -ParameterFilter { $Path -and $Path.StartsWith($env:temp\3) }
+
+```
 
 Multiple mocks of the same command may be used.
 The parameter filter determines which is invoked.
@@ -103,11 +107,12 @@ Here, if Get-ChildItem is called on the "2" directory of the temp folder, then B
 ### EXAMPLE 5
 ```powershell
 Mock Get-ChildItem { return @{FullName="B_File.TXT"} } -ParameterFilter { $Path -eq "$env:temp\me" }
-```
 
 Mock Get-ChildItem { return @{FullName="A_File.TXT"} } -ParameterFilter { $Path -and $Path.StartsWith($env:temp) }
 
 Get-ChildItem $env:temp\me
+
+```
 
 Here, both mocks could apply since both filters will pass.
 A_File.TXT will be returned because it was the most recent Mock created.
@@ -115,11 +120,12 @@ A_File.TXT will be returned because it was the most recent Mock created.
 ### EXAMPLE 6
 ```powershell
 Mock Get-ChildItem { return @{FullName = "B_File.TXT"} } -ParameterFilter { $Path -eq "$env:temp\me" }
-```
 
 Mock Get-ChildItem { return @{FullName = "A_File.TXT"} }
 
 Get-ChildItem c:\windows
+
+```
 
 Here, A_File.TXT will be returned.
 Since no filter was specified, it will apply to any call to Get-ChildItem that does not pass another filter.
@@ -127,11 +133,12 @@ Since no filter was specified, it will apply to any call to Get-ChildItem that d
 ### EXAMPLE 7
 ```powershell
 Mock Get-ChildItem { return @{FullName = "B_File.TXT"} } -ParameterFilter { $Path -eq "$env:temp\me" }
-```
 
 Mock Get-ChildItem { return @{FullName = "A_File.TXT"} }
 
 Get-ChildItem $env:temp\me
+
+```
 
 Here, B_File.TXT will be returned.
 Even though the filterless mock was created more recently.
@@ -140,6 +147,7 @@ This illustrates that filterless Mocks are always evaluated last regardless of t
 ### EXAMPLE 8
 ```powershell
 Mock Get-ChildItem { return @{FullName = "A_File.TXT"} } -ModuleName MyTestModule
+
 ```
 
 Using this Mock, all calls to Get-ChildItem from within the MyTestModule module
@@ -148,7 +156,6 @@ will return a hashtable with a FullName property returning "A_File.TXT"
 ### EXAMPLE 9
 ```powershell
 Get-Module -Name ModuleMockExample | Remove-Module
-```
 
 New-Module -Name ModuleMockExample  -ScriptBlock {
     function Hidden { "Internal Module Function" }
@@ -173,8 +180,12 @@ Describe "ModuleMockExample" {
     }
 }
 
+```
+
 This example shows how calls to commands made from inside a module can be
 mocked by using the -ModuleName parameter.
+
+
 
 ## PARAMETERS
 

--- a/docs/commands/New-Fixture.mdx
+++ b/docs/commands/New-Fixture.mdx
@@ -53,6 +53,7 @@ Describe "Clean" {
 ### EXAMPLE 1
 ```powershell
 New-Fixture -Name Clean
+
 ```
 
 Creates the scripts in the current directory.
@@ -60,6 +61,7 @@ Creates the scripts in the current directory.
 ### EXAMPLE 2
 ```powershell
 New-Fixture C:\Projects\Cleaner Clean
+
 ```
 
 Creates the scripts in the C:\Projects\Cleaner directory.
@@ -67,9 +69,12 @@ Creates the scripts in the C:\Projects\Cleaner directory.
 ### EXAMPLE 3
 ```powershell
 New-Fixture Cleaner Clean
+
 ```
 
 Creates a new folder named Cleaner in the current directory and creates the scripts in it.
+
+
 
 ## PARAMETERS
 

--- a/docs/commands/New-MockObject.mdx
+++ b/docs/commands/New-MockObject.mdx
@@ -30,10 +30,11 @@ An .NET assembly for the particular type must be available in the system and loa
 ### EXAMPLE 1
 ```powershell
 $obj = New-MockObject -Type 'System.Diagnostics.Process'
-```
 
 PS\> $obj.GetType().FullName
     System.Diagnostics.Process
+```
+
 
 ## PARAMETERS
 

--- a/docs/commands/New-PesterOption.mdx
+++ b/docs/commands/New-PesterOption.mdx
@@ -31,12 +31,15 @@ The result of New-PesterOption need to be assigned to the parameter 'PesterOptio
 ### EXAMPLE 1
 ```powershell
 $Options = New-PesterOption -TestSuiteName "Tests - Set A"
-```
 
 PS \> Invoke-Pester -PesterOption $Options -Outputfile ".\Results-Set-A.xml" -OutputFormat NUnitXML
 
+```
+
 The result of commands will be execution of tests and saving results of them in a NUnitMXL file where the root "test-suite"
 will be named "Tests - Set A".
+
+
 
 ## PARAMETERS
 

--- a/docs/commands/Set-ItResult.mdx
+++ b/docs/commands/Set-ItResult.mdx
@@ -42,7 +42,6 @@ block to either inconclusive, pending or skipped.
 ### EXAMPLE 1
 ```powershell
 Describe "Example" {
-```
 
 It "Inconclusive result test" {
         Set-ItResult -Inconclusive -Because "we want it to be inconclusive"
@@ -52,13 +51,14 @@ It "Inconclusive result test" {
 the output should be
 
 \[?\] Inconclusive result test, is inconclusive, because we want it to be inconclusive
+```
+
 Tests completed in 0ms
 Tests Passed: 0, Failed: 0, Skipped: 0, Pending: 0, Inconclusive 1
 
 ### EXAMPLE 2
 ```powershell
 Describe "Example" {
-```
 
 It "Skipped test" {
         Set-ItResult -Skipped -Because "we want it to be skipped"
@@ -68,8 +68,12 @@ It "Skipped test" {
 the output should be
 
 \[!\] Skipped test, is skipped, because we want it to be skipped
+```
+
 Tests completed in 0ms
 Tests Passed: 0, Failed: 0, Skipped: 0, Pending: 0, Inconclusive 1
+
+
 
 ## PARAMETERS
 

--- a/docs/commands/Set-TestInconclusive.mdx
+++ b/docs/commands/Set-TestInconclusive.mdx
@@ -30,7 +30,6 @@ If you need this functionality please use the new Set-ItResult command.
 ### EXAMPLE 1
 ```powershell
 Describe "Example" {
-```
 
 It "My test" {
         Set-TestInconclusive -Message "we forced it to be inconclusive"
@@ -42,6 +41,8 @@ The test result.
 
 Describing Example
     \[?\] My test, is inconclusive because we forced it to be inconclusive 58ms
+```
+
 
 ## PARAMETERS
 


### PR DESCRIPTION
It turns out multi-line examples are a real hornets-nest that come with:

- loads of exceptions
- Get-Help/PlatyPS limitations
- assumption-based decisions
- indentation
- depending on the quality of the Get-Help writer

This first batch of corrections tackles 90% of the examples to improve site-quality without waiting for the perfect solution. Manually fixed the Gherkin examples as those do not match any standard.

Refs #9 and https://github.com/alt3/Docusaurus.Powershell/issues/14