### PR TITLE
Bumps docusaurus to 2.0.0-alpha.40

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "deploy": "docusaurus deploy"
   },
   "dependencies": {
-    "@docusaurus/core": "^2.0.0-alpha.39",
-    "@docusaurus/preset-classic": "^2.0.0-alpha.39",
+    "@docusaurus/core": "^2.0.0-alpha.40",
+    "@docusaurus/preset-classic": "^2.0.0-alpha.40",
     "classnames": "^2.2.6",
     "prismjs": "^1.17.1",
     "react": "^16.8.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -758,10 +758,10 @@
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
   integrity sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==
 
-"@docusaurus/core@^2.0.0-alpha.39":
-  version "2.0.0-alpha.39"
-  resolved "https://registry.yarnpkg.com/@docusaurus/core/-/core-2.0.0-alpha.39.tgz#672310dba296ede738d9788acf13722aa4a43cb9"
-  integrity sha512-ZIW+TXBi+ZYGuOGUrIDCtVHmhJt4FTjr5YIOtKl1tjWBjidyIFjttkCP07SPEprHtVeXghZ/LeX6gq38kWrTBw==
+"@docusaurus/core@^2.0.0-alpha.40":
+  version "2.0.0-alpha.40"
+  resolved "https://registry.yarnpkg.com/@docusaurus/core/-/core-2.0.0-alpha.40.tgz#cefc79156b89316317aee289fc68547b1d0ced04"
+  integrity sha512-3mVw7vXm6Ad53+1qKvYD3EzULC/JyWH8dUlysLzbsWx3M6+ZJ4NNdNTtLM4Uuug8OdnbhIJL244O4wSeRT5U3Q==
   dependencies:
     "@babel/core" "^7.7.4"
     "@babel/plugin-syntax-dynamic-import" "^7.7.4"
@@ -769,7 +769,7 @@
     "@babel/preset-env" "^7.7.4"
     "@babel/preset-react" "^7.7.4"
     "@babel/runtime" "^7.7.4"
-    "@docusaurus/utils" "^2.0.0-alpha.39"
+    "@docusaurus/utils" "^2.0.0-alpha.40"
     "@endiliey/static-site-generator-webpack-plugin" "^4.0.0"
     babel-loader "^8.0.6"
     babel-plugin-dynamic-import-node "^2.3.0"
@@ -786,6 +786,7 @@
     express "^4.17.1"
     fs-extra "^8.1.0"
     globby "^10.0.1"
+    html-minifier-terser "^5.0.2"
     html-tags "^3.1.0"
     html-webpack-plugin "^4.0.0-beta.11"
     import-fresh "^3.2.1"
@@ -807,7 +808,6 @@
     semver "^6.3.0"
     shelljs "^0.8.3"
     std-env "^2.2.1"
-    style-loader "^1.0.1"
     terser-webpack-plugin "^2.2.1"
     wait-file "^1.0.5"
     webpack "^4.41.2"
@@ -816,16 +816,17 @@
     webpack-merge "^4.2.2"
     webpackbar "^4.0.0"
 
-"@docusaurus/mdx-loader@^2.0.0-alpha.39":
-  version "2.0.0-alpha.39"
-  resolved "https://registry.yarnpkg.com/@docusaurus/mdx-loader/-/mdx-loader-2.0.0-alpha.39.tgz#31237b83fadf79ed8e4897401888583fd8532f76"
-  integrity sha512-rYT5Q3Ryk1FWdxOKbOGVRbC4aNr49C8KmzmjHSCX2ke0FXEgGrPaCtMN9n38zADtJ1a63ZFr3eQqPmyX2sEX5g==
+"@docusaurus/mdx-loader@^2.0.0-alpha.40":
+  version "2.0.0-alpha.40"
+  resolved "https://registry.yarnpkg.com/@docusaurus/mdx-loader/-/mdx-loader-2.0.0-alpha.40.tgz#26670dd07ff4b91831257f9b375400fe05a10e0c"
+  integrity sha512-v63OQKDf2DxN5SG9brKC2h5xDY9I8e0CGs/uNMF6txpVA/XYTNc2yP+XXUZS3Vx9xVIPH8uLruTZr5/bx2XH7w==
   dependencies:
     "@babel/parser" "^7.7.4"
     "@babel/traverse" "^7.7.4"
     "@mdx-js/mdx" "^1.5.1"
     "@mdx-js/react" "^1.5.1"
     escape-html "^1.0.3"
+    fs-extra "^8.1.0"
     github-slugger "^1.2.1"
     gray-matter "^4.0.2"
     loader-utils "^1.2.3"
@@ -835,26 +836,26 @@
     stringify-object "^3.3.0"
     unist-util-visit "^2.0.1"
 
-"@docusaurus/plugin-content-blog@^2.0.0-alpha.39":
-  version "2.0.0-alpha.39"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.0.0-alpha.39.tgz#0ab951136147efb4f17307b45eb1f0133c40c86d"
-  integrity sha512-Z95KD553HCGhQjMY6ytU+ses/7SgF5umIXW+22L5nVemwmF4huAfQhy1ekBPxyfojPH/1Yc+IKdEr85hjTcxwA==
+"@docusaurus/plugin-content-blog@^2.0.0-alpha.40":
+  version "2.0.0-alpha.40"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.0.0-alpha.40.tgz#e586f2af7e4736094eb4af5d2cc305877e4ef80a"
+  integrity sha512-iLCWtkQNe08+kYWlZC52WE3b3LDoYqh7mQYr2sOPmuZYmUv6wm88I7QMP3FlEpSIsYrIVy6yRoOGpD7Lf43wlA==
   dependencies:
-    "@docusaurus/mdx-loader" "^2.0.0-alpha.39"
-    "@docusaurus/utils" "^2.0.0-alpha.39"
+    "@docusaurus/mdx-loader" "^2.0.0-alpha.40"
+    "@docusaurus/utils" "^2.0.0-alpha.40"
     feed "^4.0.0"
     fs-extra "^8.1.0"
     globby "^10.0.1"
     loader-utils "^1.2.3"
     lodash "^4.17.15"
 
-"@docusaurus/plugin-content-docs@^2.0.0-alpha.39":
-  version "2.0.0-alpha.39"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.0.0-alpha.39.tgz#5b538b0c37ccd6b26114670642b01f6ff43b4528"
-  integrity sha512-LUaNXneUoG4M1S+o3XsEr35MHp+pIHtjQZ3Y7x48datfUasXrr4iQqaL2bP/Poc6gEU7sedIxKruTm3KK79GcA==
+"@docusaurus/plugin-content-docs@^2.0.0-alpha.40":
+  version "2.0.0-alpha.40"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.0.0-alpha.40.tgz#acec3e8b7c9deba415131fb8b53b618c039b06b5"
+  integrity sha512-cZgGJGNtYXlR2CQI7EuPyzf7DV1RvX+gRSRcPn979XxuLyk2GRWJ1/ODS3jkjQOfTat1QMFYvFrF5vYAgN6Drg==
   dependencies:
-    "@docusaurus/mdx-loader" "^2.0.0-alpha.39"
-    "@docusaurus/utils" "^2.0.0-alpha.39"
+    "@docusaurus/mdx-loader" "^2.0.0-alpha.40"
+    "@docusaurus/utils" "^2.0.0-alpha.40"
     execa "^3.4.0"
     fs-extra "^8.1.0"
     globby "^10.0.1"
@@ -863,51 +864,51 @@
     lodash "^4.17.15"
     shelljs "^0.8.3"
 
-"@docusaurus/plugin-content-pages@^2.0.0-alpha.39":
-  version "2.0.0-alpha.39"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.0.0-alpha.39.tgz#1139f38f5a773b35a50a482253a8403f8542c55e"
-  integrity sha512-68MXNYAfcbI395AF3bzbrVljLico57QhOufkPIhgq3eRE26lMsX21K2zqRrBytxuMrmAc2hEBEX6m44Wj2YEWQ==
+"@docusaurus/plugin-content-pages@^2.0.0-alpha.40":
+  version "2.0.0-alpha.40"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.0.0-alpha.40.tgz#2edc4f906d9e30d4adac834d1a5ac8fab54b703e"
+  integrity sha512-igSyxGgzuJASLJ5969hyYx2x5B2jNDPu28BEiDbWP3sx1hwVZ+p+kXB8BlY1zlQob/NCGRH2LAR2Cyyb6o3Ntg==
   dependencies:
-    "@docusaurus/types" "^2.0.0-alpha.39"
-    "@docusaurus/utils" "^2.0.0-alpha.39"
+    "@docusaurus/types" "^2.0.0-alpha.40"
+    "@docusaurus/utils" "^2.0.0-alpha.40"
     globby "^10.0.1"
 
-"@docusaurus/plugin-google-analytics@^2.0.0-alpha.39":
-  version "2.0.0-alpha.39"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.0.0-alpha.39.tgz#82be38d748f9886fcbdc9b9082cdcb77c2b79c5b"
-  integrity sha512-cbNVu1PSYsbuLV9Xr2eY1I6OaUmZkq5tn2ggClMwZz1r+NcqkAiMsOQdNX7cLkcQiptKwQWUik16NxHbT2PeTg==
+"@docusaurus/plugin-google-analytics@^2.0.0-alpha.40":
+  version "2.0.0-alpha.40"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.0.0-alpha.40.tgz#1967ff433c1dfc3d0cf29e17bc078232f2344119"
+  integrity sha512-vWkx63QadZgxTi2J+nLRnAd4uuCJT/F1rhRB8wVoUR/Vkeo463oufNWQL5yDpC1FA2d54zAwaLbjSbTSyuD4TA==
 
-"@docusaurus/plugin-google-gtag@^2.0.0-alpha.39":
-  version "2.0.0-alpha.39"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.0.0-alpha.39.tgz#35566402cfabcea36ae84e7ecdb1e2045ae6cacf"
-  integrity sha512-p2qDx1JHTcoTPfdEcuYM1KY8pe2HayCVCu/PYiB5tkLEhATDiv/7TEDry1/cuvx+YQcg98E7amiCofWtZkYgkQ==
+"@docusaurus/plugin-google-gtag@^2.0.0-alpha.40":
+  version "2.0.0-alpha.40"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.0.0-alpha.40.tgz#9f6e372c39175615a70f53cdd4d4bb91fbbb07ac"
+  integrity sha512-2cBdCAsgLGg2uqSFf85GfUxsuqlmBIpmJhQrA/4Bc+ECc9mPxVq4UdD3C8YafUbiUzgNB2GTRv1igMBM4d7hEQ==
 
-"@docusaurus/plugin-sitemap@^2.0.0-alpha.39":
-  version "2.0.0-alpha.39"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.0.0-alpha.39.tgz#9401d4564064bf398c2fcca927837884ba6f6ed2"
-  integrity sha512-qvDOmXTLVy5iwRRhV/S642iszxvtiQNmQwqoTpP4mjYzNIoPs/F0Dsc0VN2K0XW6dLtJsRl+wrTCNvwPY7cFng==
+"@docusaurus/plugin-sitemap@^2.0.0-alpha.40":
+  version "2.0.0-alpha.40"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.0.0-alpha.40.tgz#32c9fdff8fee20fbebb18f15fd49a2b01a2560b5"
+  integrity sha512-Z7VoC1o8+9gsy8LCiqgkYJmWKqzpIKjfydD5AX0D46vWMohfCnDIvWPKS4uN7BcCm9HRL786tJu3v3821N8I0A==
   dependencies:
-    "@docusaurus/types" "^2.0.0-alpha.39"
+    "@docusaurus/types" "^2.0.0-alpha.40"
     sitemap "^3.2.2"
 
-"@docusaurus/preset-classic@^2.0.0-alpha.39":
-  version "2.0.0-alpha.39"
-  resolved "https://registry.yarnpkg.com/@docusaurus/preset-classic/-/preset-classic-2.0.0-alpha.39.tgz#ff2c458e4c39276c6146574f2ec8bfded49b7ea6"
-  integrity sha512-nJZ3Ze5/DEi6sCkr3s4JfYXBXqvS9kJ48SFl8Bkvxs5iamuVRI1AZZWcyJhIGtJxV6TJNLdp0SHu7NM0XU50Mw==
+"@docusaurus/preset-classic@^2.0.0-alpha.40":
+  version "2.0.0-alpha.40"
+  resolved "https://registry.yarnpkg.com/@docusaurus/preset-classic/-/preset-classic-2.0.0-alpha.40.tgz#7b45eb699c8512a3601c9dd2707b1c283edd8d6a"
+  integrity sha512-CALOb3aB1WR9JbK6ogMosy4ReZnkvtfCOJy49ibQqdVcJnmI46CbBscjHgbNph87tY9U/uzRb32XlP7mcScmng==
   dependencies:
-    "@docusaurus/plugin-content-blog" "^2.0.0-alpha.39"
-    "@docusaurus/plugin-content-docs" "^2.0.0-alpha.39"
-    "@docusaurus/plugin-content-pages" "^2.0.0-alpha.39"
-    "@docusaurus/plugin-google-analytics" "^2.0.0-alpha.39"
-    "@docusaurus/plugin-google-gtag" "^2.0.0-alpha.39"
-    "@docusaurus/plugin-sitemap" "^2.0.0-alpha.39"
-    "@docusaurus/theme-classic" "^2.0.0-alpha.39"
-    "@docusaurus/theme-search-algolia" "^2.0.0-alpha.39"
+    "@docusaurus/plugin-content-blog" "^2.0.0-alpha.40"
+    "@docusaurus/plugin-content-docs" "^2.0.0-alpha.40"
+    "@docusaurus/plugin-content-pages" "^2.0.0-alpha.40"
+    "@docusaurus/plugin-google-analytics" "^2.0.0-alpha.40"
+    "@docusaurus/plugin-google-gtag" "^2.0.0-alpha.40"
+    "@docusaurus/plugin-sitemap" "^2.0.0-alpha.40"
+    "@docusaurus/theme-classic" "^2.0.0-alpha.40"
+    "@docusaurus/theme-search-algolia" "^2.0.0-alpha.40"
 
-"@docusaurus/theme-classic@^2.0.0-alpha.39":
-  version "2.0.0-alpha.39"
-  resolved "https://registry.yarnpkg.com/@docusaurus/theme-classic/-/theme-classic-2.0.0-alpha.39.tgz#f13f36784f396561fa3601f1978f3ee396478475"
-  integrity sha512-yGdpNQINC5Db5hBA/CXrgcWlS2Y4lKgllMhXaT5KwM4ZMa6TLlo+P4mSRPnxCuPslg4vRWnd5QOiQ9AykXUNWw==
+"@docusaurus/theme-classic@^2.0.0-alpha.40":
+  version "2.0.0-alpha.40"
+  resolved "https://registry.yarnpkg.com/@docusaurus/theme-classic/-/theme-classic-2.0.0-alpha.40.tgz#e6b6ee684d9499a895d2df894b4772db9d299939"
+  integrity sha512-kksNoAD4AD/klNJAuMWIWvkTP3aV85iozoNeihLALbTGQejEWxCbRL+dBjUflhF9zrKcvZP3s905hKj7Xt3B3g==
   dependencies:
     "@mdx-js/mdx" "^1.5.1"
     "@mdx-js/react" "^1.5.1"
@@ -918,27 +919,27 @@
     prism-react-renderer "^1.0.2"
     react-toggle "^4.1.1"
 
-"@docusaurus/theme-search-algolia@^2.0.0-alpha.39":
-  version "2.0.0-alpha.39"
-  resolved "https://registry.yarnpkg.com/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.0.0-alpha.39.tgz#1fc292b39ce627abb07193c0cf37a019cb7be5ae"
-  integrity sha512-Ssr3lZ178+Kd4rxDp0X4DmH1TjzSdJk3elOiE5ozmjDM49yEbRiAQ7u7C9h+QC+m14xi+UFa67+8oLRKLYJ2qA==
+"@docusaurus/theme-search-algolia@^2.0.0-alpha.40":
+  version "2.0.0-alpha.40"
+  resolved "https://registry.yarnpkg.com/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.0.0-alpha.40.tgz#f3f133d8ff392cfee5d5e1f7c102f6800bf54516"
+  integrity sha512-dCCu7JN5/WmJv6bBTpgbCuvz6LlQr6/pRMsWsShQPxal7JpgMAyVjLCdqL9byY+mJONQrWbpxPTWEHl9nZ9Mdw==
   dependencies:
     classnames "^2.2.6"
     docsearch.js "^2.6.3"
 
-"@docusaurus/types@^2.0.0-alpha.39":
-  version "2.0.0-alpha.39"
-  resolved "https://registry.yarnpkg.com/@docusaurus/types/-/types-2.0.0-alpha.39.tgz#1bcbbbb337ba409adb510fdfeb8d0756d5677310"
-  integrity sha512-LSGwhk63KIhH3haVsTb3W7ttIZD0Vxu831LvBW1OAYm9POY9tC1sAcHbnAxnbGDL5K9QO4GNciiYW2CAoqhO8A==
+"@docusaurus/types@^2.0.0-alpha.40":
+  version "2.0.0-alpha.40"
+  resolved "https://registry.yarnpkg.com/@docusaurus/types/-/types-2.0.0-alpha.40.tgz#be0af577dd6f4ef3202620f7e21acc7843a56bee"
+  integrity sha512-CcEVeONauYMaqECauAwt9p9ux4r8C7ww+ipaSLxG9wwzeYVgoVPWnIDlKSBIyx2UBWzGz4er+V6eGpHLY15x8Q==
   dependencies:
     "@types/webpack" "^4.41.0"
     commander "^4.0.1"
     querystring "0.2.0"
 
-"@docusaurus/utils@^2.0.0-alpha.39":
-  version "2.0.0-alpha.39"
-  resolved "https://registry.yarnpkg.com/@docusaurus/utils/-/utils-2.0.0-alpha.39.tgz#2a354137abc0b54e0f2a38280ac1ae897d97759d"
-  integrity sha512-mG7Cp60VlTALPBfxDqds57lCsmhDvzVlGZ+gTWFhGgyr9G/Go9faHh8gZnVl4Wdjd1jGM4Pw52tT8tUjnEXwHg==
+"@docusaurus/utils@^2.0.0-alpha.40":
+  version "2.0.0-alpha.40"
+  resolved "https://registry.yarnpkg.com/@docusaurus/utils/-/utils-2.0.0-alpha.40.tgz#fbbde31886ea1076a8d14e2133f07a6d35cf158e"
+  integrity sha512-MR1nD3o23PuyWuSX0n+bGXlGfWt08w1xrVDRb+J4M3LrOflSlgI2RaT2p3J7V/czNWcvfCjhknVNXqpVTViw6A==
   dependencies:
     escape-string-regexp "^2.0.0"
     fs-extra "^8.1.0"
@@ -4163,7 +4164,7 @@ html-entities@^1.2.1:
   resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-1.2.1.tgz#0df29351f0721163515dfb9e5543e5f6eed5162f"
   integrity sha1-DfKTUfByEWNRXfueVUPl9u7VFi8=
 
-html-minifier-terser@^5.0.1:
+html-minifier-terser@^5.0.1, html-minifier-terser@^5.0.2:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/html-minifier-terser/-/html-minifier-terser-5.0.2.tgz#0e67a0b062ae1dd0719fc73199479298f807ae16"
   integrity sha512-VAaitmbBuHaPKv9bj47XKypRhgDxT/cDLvsPiiF7w+omrN3K0eQhpigV9Z1ilrmHa9e0rOYcD6R/+LCDADGcnQ==
@@ -7616,7 +7617,7 @@ schema-utils@^1.0.0:
     ajv-errors "^1.0.0"
     ajv-keywords "^3.1.0"
 
-schema-utils@^2.0.0, schema-utils@^2.0.1, schema-utils@^2.6.0, schema-utils@^2.6.1:
+schema-utils@^2.0.0, schema-utils@^2.6.0, schema-utils@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-2.6.1.tgz#eb78f0b945c7bcfa2082b3565e8db3548011dc4f"
   integrity sha512-0WXHDs1VDJyo+Zqs9TKLKyD/h7yDpHUhEFsM2CzkICFdoX1av+GBq/J2xRTFfsQO5kBfhZzANf2VcIm84jqDbg==
@@ -8169,14 +8170,6 @@ strip-final-newline@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
   integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
-
-style-loader@^1.0.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-1.1.1.tgz#8290d915dffe820916790cdcab5aa58c38ab605c"
-  integrity sha512-oIVF12trRq0od4Yojg7q0K3Lq/O6Ix/AYgVosykrVg+kWxxxUyk8KhKCCmekyGSUiVK1xxlAQymLWWdh6S9lOg==
-  dependencies:
-    loader-utils "^1.2.3"
-    schema-utils "^2.0.1"
 
 style-to-object@0.3.0:
   version "0.3.0"


### PR DESCRIPTION
This removes the flaws when running the site locally.

Always remember to **commit both** updated `package.json` and `yarn.lock` (used by e.g. Netlify)