### PR TITLE
Finalize Broken Links issue template

### DIFF
--- a/.github/workflows/check-broken-links.md
+++ b/.github/workflows/check-broken-links.md
@@ -4,6 +4,10 @@ labels: housekeeping
 assignees: ''
 ---
 
-The Broken Link Checker found :coffin: links on the pester.dev website.
+## Website Contains Broken Links
+
+Broken Link Checker found :coffin: links on [https://pester.dev](https://pester.dev).
 
 [View results](https://github.com/pester/docs/commit/{{sha}}//checks)
+
+_Use search filter `─BROKEN─` to highlight failures_


### PR DESCRIPTION
This PR (only) updates the markdown template used to create the monthly Broken Links github action so that the created issue will look similar to the one below:

![image](https://user-images.githubusercontent.com/230500/78423557-62d42200-7667-11ea-8eaa-642bdc792955.png)
