### PR TITLE
Update browser/tab title for home

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -66,7 +66,7 @@ function Home() {
   const {siteConfig = {}} = context;
   return (
     <Layout
-      title={`Hello from ${siteConfig.title}`}
+      title={`${siteConfig.title} - The ubiquitous test and mock framework for PowerShell`}
       description="Description will go into a meta tag in <head />">
       <header className={classnames('hero hero--primary', styles.heroBanner)}>
         <div className="container">


### PR DESCRIPTION
This changes the tab title for /home from

> Hello from Pester

to 

> Pester -  The ubiquitous test and mock framework for PowerShell

so it looks like this in the browser:

![image](https://user-images.githubusercontent.com/230500/72664468-8d1a2a00-39fe-11ea-8675-f1651c6819bc.png)
