### PR TITLE
Replace wiki-links with valid markdown links

### DIFF
--- a/docs/quick-start.mdx
+++ b/docs/quick-start.mdx
@@ -85,7 +85,7 @@ or altered by a command and an expected value (see [Should](./commands/Should)).
 
 ## Running a Pester test
 
-Use the [Invoke-Pester](./commands/Invoke-Pester) command to run tests (see [Invoke-Pester](./commands/Invoke-Pester). [Invoke-Pester](./commands/Invoke-Pester) be run against all the
+Use the [Invoke-Pester](./commands/Invoke-Pester) command to run tests (see [Invoke-Pester](./commands/Invoke-Pester)). [Invoke-Pester](./commands/Invoke-Pester) can be run against all the
 `\*.Tests.ps1` files in an entire tree of directories or it can zero in on just one test group (`Describe` block)
 using `-TestName` parameter. The `-Tag` parameter in the [Describe](./commands/Describe) block can also be used for targeted testing,
 categorization and filtering of tests.

--- a/docs/quick-start.mdx
+++ b/docs/quick-start.mdx
@@ -129,7 +129,7 @@ The MSBuild example will start a PowerShell session, import the Pester Module an
 within the current directory. If any test fails, it will return an exit code equal to the number of failed
 tests and all test results will be saved to Test.xml using NUnit's Schema. This file can be published as
 test results as part of the build into most build systems like Azure Devops, CruiseControl, TeamCity, TFS
-or Jenkins. See [[Showing Test Results in CI (TeamCity, AppVeyor, Azure DevOps)]]
+or Jenkins. See [Showing Test Results in CI (TeamCity, AppVeyor, Azure DevOps)](./usage/test-results)
 
 ## Other Examples
 

--- a/docs/quick-start.mdx
+++ b/docs/quick-start.mdx
@@ -20,15 +20,15 @@ include functions, Cmdlets, Modules and scripts. Pester can be run in ad-hoc sty
 
 Pester contains a powerful set of Mocking Functions that allow tests to mimic and mock the
 functionality of any command inside of a piece of PowerShell code being tested. See
-[Mocking with Pester](../usage/mocking).
+[Mocking with Pester](./usage/mocking).
 
 Pester can produce artifacts such as Test Results and can be used for Generating
-[Code Coverage Metrics](../usage/code-coverage) metrics output files which can be used
-for reporting purposes and in build pipelines. See [Showing Test-Results in CI](../usage/test-results).
+[Code Coverage Metrics](./usage/code-coverage) metrics output files which can be used
+for reporting purposes and in build pipelines. See [Showing Test-Results in CI](./usage/test-results).
 
 ## Creating a Pester Test
 
-To start using Pester, use the optional [New-Fixture](../commands/New-Fixture) function to scaffold
+To start using Pester, use the optional [New-Fixture](./commands/New-Fixture) function to scaffold
 both a new implementation function and a test function. New-Fixture assumes that you will be testing
 the contents of a `.ps1` file (not a `.psm1` file, or Script Module), that the test script should be
 in the same directory as the script under test, and that the name of the test script should be
@@ -74,27 +74,27 @@ Invoke-Pester -Script .\Test-ScriptWithPesterTest.ps1
 
 In addition to filename discovery of the `\*.Tests.ps1` pattern by the [Invoke-Pester](./commands/Invoke-Pester)
 command, Pester discovers `Describe` blocks (logical groupings of tests) within the test file
-(see [Describe](../commands/Describe)).
+(see [Describe](./commands/Describe)).
 
-The `Describe` block can contain several behavior validations expressed in [[It]] blocks (see [[It]]).
-Each [[It]] block should test one thing and throw an exception if the test fails. Pester will consider any
- [[It]] block that throws an exception to be a failed test.
+The `Describe` block can contain several behavior validations expressed in [It](./commands/It) blocks (see [It](./commands/It)).
+Each [It](./commands/It) block should test one thing and throw an exception if the test fails. Pester will consider any
+ [It](./commands/It) block that throws an exception to be a failed test.
 
-Pester provides a command called [[Should]] that can perform various comparisons between the values emitted
-or altered by a command and an expected value (see [[Should]]).
+Pester provides a command called [Should](./commands/Should) that can perform various comparisons between the values emitted
+or altered by a command and an expected value (see [Should](./commands/Should)).
 
 ## Running a Pester test
 
-Use the [[Invoke‐Pester]] command to run tests (see [[Invoke‐Pester]]). [[Invoke‐Pester]] be run against all the
+Use the [Invoke-Pester](./commands/Invoke-Pester) command to run tests (see [Invoke-Pester](./commands/Invoke-Pester). [Invoke-Pester](./commands/Invoke-Pester) be run against all the
 `\*.Tests.ps1` files in an entire tree of directories or it can zero in on just one test group (`Describe` block)
-using `-TestName` parameter. The `-Tag` parameter in the [[Describe]] block can also be used for targeted testing,
+using `-TestName` parameter. The `-Tag` parameter in the [Describe](./commands/Describe) block can also be used for targeted testing,
 categorization and filtering of tests.
 
 As of Pester version 3.0, direct execution of any `.Tests.ps1` script file is available without using
-[[Invoke‐Pester]] test harness; with test output written to the console. By running tests directly, many
+[Invoke-Pester](./commands/Invoke-Pester) test harness; with test output written to the console. By running tests directly, many
 of the benefits of the test framework are unavailable.
 
-Benefits to running from [[Invoke-Pester]] test framework include the following:
+Benefits to running from [Invoke-Pester](./commands/Invoke-Pester) test framework include the following:
 
 - Produce NUnit XML files or other output objects
 - Code Coverage analysis.
@@ -104,7 +104,7 @@ Benefits to running from [[Invoke-Pester]] test framework include the following:
 
 ## Pester and Continuous Integration (CI)
 
-Pester integrates with almost any build automation solution. See [[Showing Test Results in CI (TeamCity, AppVeyor, Azure DevOps)]]
+Pester integrates with almost any build automation solution. See [Showing Test Results in CI (TeamCity, AppVeyor, Azure DevOps)](./usage/test-results)
 
 An example of a PowerShell script to run against a single pester test file using an Azure Devops Inline Powershell script task.
 
@@ -125,7 +125,7 @@ An example of an MSBuild target that calls Pester's convenience helper Batch fil
 </Target>
 ```
 
-The MSBuild example will start a PowerShell session, import the Pester Module and call [[Invoke‐Pester]]
+The MSBuild example will start a PowerShell session, import the Pester Module and call [Invoke-Pester](./commands/Invoke-Pester)
 within the current directory. If any test fails, it will return an exit code equal to the number of failed
 tests and all test results will be saved to Test.xml using NUnit's Schema. This file can be published as
 test results as part of the build into most build systems like Azure Devops, CruiseControl, TeamCity, TFS

--- a/docs/usage/assertions.mdx
+++ b/docs/usage/assertions.mdx
@@ -4,7 +4,7 @@ title: Performing Assertions with Should
 sidebar_label: Assertions
 ---
 
-:warning: All information on this page are relevant to Pester v. 4.x. You can read older version of this page - relevant to Pester v. 3.x - [[here|Should-v3]].
+:warning: All information on this page are relevant to Pester v. 4.x. You can read older version of this page - relevant to Pester v. 3.x - [here](https://github.com/pester/Pester/wiki/Should-v3).
 
 `Should` is a command that provides assertion convenience methods for comparing objects and throwing test failures when test expectations fail. `Should` is used inside `It` blocks of a Pester test script.
 

--- a/docs/usage/modules.mdx
+++ b/docs/usage/modules.mdx
@@ -73,7 +73,7 @@ Describe "BuildIfChanged" {
 }
 ```
 
-Notice that in this example test script, all calls to [Mock](../commands/Mock) and [Assert‐MockCalled](../commands/Assert-MockCalled] have had the `-ModuleName MyModule` parameter added.  This tells Pester to inject the mock into the module's scope, which causes any calls to those commands from inside the module to execute the mock instead.
+Notice that in this example test script, all calls to [Mock](../commands/Mock) and [Assert‐MockCalled](../commands/Assert-MockCalled) have had the `-ModuleName MyModule` parameter added.  This tells Pester to inject the mock into the module's scope, which causes any calls to those commands from inside the module to execute the mock instead.
 
 When you write your test script this way, you can mock commands that are called by the module's internal functions.  However, your test script is still limited to accessing the public, exported members of the module.  If you wanted to write a unit test that calls Build directly, for example, it wouldn't work using the above technique.  That's where the second approach to script module testing comes into play.  With Pester 3.0's `InModuleScope` command, you can cause entire sections of your test script to execute inside the targeted script module.  This gives you access to non-exported members of the module.  For example:
 

--- a/docs/usage/modules.mdx
+++ b/docs/usage/modules.mdx
@@ -73,7 +73,7 @@ Describe "BuildIfChanged" {
 }
 ```
 
-Notice that in this example test script, all calls to [[Mock]] and [[Assert‐MockCalled]] have had the `-ModuleName MyModule` parameter added.  This tells Pester to inject the mock into the module's scope, which causes any calls to those commands from inside the module to execute the mock instead.
+Notice that in this example test script, all calls to [Mock](../commands/Mock) and [Assert‐MockCalled](../commands/Assert-MockCalled] have had the `-ModuleName MyModule` parameter added.  This tells Pester to inject the mock into the module's scope, which causes any calls to those commands from inside the module to execute the mock instead.
 
 When you write your test script this way, you can mock commands that are called by the module's internal functions.  However, your test script is still limited to accessing the public, exported members of the module.  If you wanted to write a unit test that calls Build directly, for example, it wouldn't work using the above technique.  That's where the second approach to script module testing comes into play.  With Pester 3.0's `InModuleScope` command, you can cause entire sections of your test script to execute inside the targeted script module.  This gives you access to non-exported members of the module.  For example:
 

--- a/docs/usage/testdrive.mdx
+++ b/docs/usage/testdrive.mdx
@@ -10,11 +10,11 @@ A test may need to work with file operations and validate certain types of file 
 
 ## Scoping
 
-Basic scoping rules are implemented for the TestDrive. A clean TestDrive is created for every [[Describe]] and all the files created are available in the whole [[Describe]] scope. If the [[Context]] keyword is also used the state of the TestDrive is recorded before moving into the Context block. Inside the [[Context]] block the files from the [[Describe]] scope are available for reading and modification. You can move them around and create new ones as well.
+Basic scoping rules are implemented for the TestDrive. A clean TestDrive is created for every [Describe](../commands/Describe) and all the files created are available in the whole [Describe](../commands/Describe) scope. If the [Context](../commands/Context) keyword is also used the state of the TestDrive is recorded before moving into the Context block. Inside the [Context](../commands/Context) block the files from the [Describe](../commands/Describe) scope are available for reading and modification. You can move them around and create new ones as well.
 
-Once the [[Context]] block is finished all the files created inside that block are deleted, leaving only the files created in the Describe block. When the Describe block is finished all contents of the TestDrive are discarded.
+Once the [Context](../commands/Context) block is finished all the files created inside that block are deleted, leaving only the files created in the Describe block. When the Describe block is finished all contents of the TestDrive are discarded.
 
-Recording the state of the drive is done by saving a list of the files and folders present on the drive. No snapshots or any other magic is done. In practice this means that if you create a file in the [[Describe]] block and then change its content inside the Context block, the modifications are preserved even after you left the [[Context]] block.
+Recording the state of the drive is done by saving a list of the files and folders present on the drive. No snapshots or any other magic is done. In practice this means that if you create a file in the [Describe](../commands/Describe) block and then change its content inside the Context block, the modifications are preserved even after you left the [Context](../commands/Context) block.
 
 Internally the TestDrive creates a randomly named folder placed in $env:Temp and links it to the TestDrive PSDrive. Making the folder names random enables you to run multiple instances of Pester in parallel, as long as they are running as separate processes. That means running in different PowerShell.exe sessions or running using PowerShell jobs.
 

--- a/docs/usage/testregistry.mdx
+++ b/docs/usage/testregistry.mdx
@@ -10,7 +10,7 @@ Pester creates a temporary, randomly named (a guid), registry key in the current
 
 ## Scoping
 
-Basic scoping rules are implemented for the TestRegistry in a similar way to [[TestDrive]]. A clean TestRegistry is created on entry to every Describe block and all the keys and values created by your tests are available during the lifetime of that Describe scope. One important difference from [[TestDrive]] is that registry keys and values persist within the Describe block and any changes to the registry in the scope of an It or Context block remain until the scope of the Describe block ends. When the Describe block is finished the temporary registry key is deleted and all the subkeys and values with it.
+Basic scoping rules are implemented for the TestRegistry in a similar way to [TestDrive](./testdrive). A clean TestRegistry is created on entry to every Describe block and all the keys and values created by your tests are available during the lifetime of that Describe scope. One important difference from [TestDrive](./testdrive) is that registry keys and values persist within the Describe block and any changes to the registry in the scope of an It or Context block remain until the scope of the Describe block ends. When the Describe block is finished the temporary registry key is deleted and all the subkeys and values with it.
 
 ## Example
 


### PR DESCRIPTION
Replaced formatting of [[foo]] links with [foo](link_path) format. Fixed some broken links in the quick-start page. 