### PR TITLE
docs: update command reference links (using pester fix-doc-links PR)

### DIFF
--- a/docs/commands/AfterAll.mdx
+++ b/docs/commands/AfterAll.mdx
@@ -68,4 +68,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[https://pester.dev/docs/commands/AfterAll](https://pester.dev/docs/commands/AfterAll)
+[https://pester.dev/docs/commands/BeforeAll](https://pester.dev/docs/commands/BeforeAll)

--- a/docs/commands/AfterAll.mdx
+++ b/docs/commands/AfterAll.mdx
@@ -68,6 +68,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[https://github.com/pester/Pester/wiki/BeforeEach-and-AfterEach](https://github.com/pester/Pester/wiki/BeforeEach-and-AfterEach)
-
-[about_BeforeEach_AfterEach]()
+[https://pester.dev/docs/commands/AfterAll](https://pester.dev/docs/commands/AfterAll)

--- a/docs/commands/AfterEach.mdx
+++ b/docs/commands/AfterEach.mdx
@@ -71,4 +71,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[https://pester.dev/docs/commands/AfterEach](https://pester.dev/docs/commands/AfterEach)
+[https://pester.dev/docs/commands/BeforeEach](https://pester.dev/docs/commands/BeforeEach)

--- a/docs/commands/AfterEach.mdx
+++ b/docs/commands/AfterEach.mdx
@@ -71,6 +71,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[https://github.com/pester/Pester/wiki/BeforeEach-and-AfterEach](https://github.com/pester/Pester/wiki/BeforeEach-and-AfterEach)
-
-[about_BeforeEach_AfterEach]()
+[https://pester.dev/docs/commands/AfterEach](https://pester.dev/docs/commands/AfterEach)

--- a/docs/commands/AfterEachFeature.mdx
+++ b/docs/commands/AfterEachFeature.mdx
@@ -93,6 +93,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[BeforeEachFeature
-BeforeEachScenario
-AfterEachScenario]()
+[BeforeEachFeature]()
+
+[BeforeEachScenario]()
+
+[AfterEachScenario]()

--- a/docs/commands/AfterEachFeature.mdx
+++ b/docs/commands/AfterEachFeature.mdx
@@ -93,8 +93,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[BeforeEachFeature]()
+[https://pester.dev/docs/commands/BeforeEachFeature](https://pester.dev/docs/commands/BeforeEachFeature)
 
-[BeforeEachScenario]()
+[https://pester.dev/docs/commands/BeforeEachScenario](https://pester.dev/docs/commands/BeforeEachScenario)
 
-[AfterEachScenario]()
+[https://pester.dev/docs/commands/AfterEachScenario](https://pester.dev/docs/commands/AfterEachScenario)

--- a/docs/commands/AfterEachScenario.mdx
+++ b/docs/commands/AfterEachScenario.mdx
@@ -93,6 +93,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[BeforeEachFeature
-BeforeEachScenario
-AfterEachScenario]()
+[BeforeEachFeature]()
+
+[BeforeEachScenario]()
+
+[AfterEachScenario]()

--- a/docs/commands/AfterEachScenario.mdx
+++ b/docs/commands/AfterEachScenario.mdx
@@ -93,8 +93,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[BeforeEachFeature]()
+[https://pester.dev/docs/commands/BeforeEachScenario](https://pester.dev/docs/commands/BeforeEachScenario)
 
-[BeforeEachScenario]()
+[https://pester.dev/docs/commands/BeforeEachFeature](https://pester.dev/docs/commands/BeforeEachFeature)
 
-[AfterEachScenario]()
+[https://pester.dev/docs/commands/AfterEachFeature](https://pester.dev/docs/commands/AfterEachFeature)

--- a/docs/commands/Assert-VerifiableMocks.mdx
+++ b/docs/commands/Assert-VerifiableMocks.mdx
@@ -52,6 +52,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[https://github.com/pester/Pester/wiki/Migrating-from-Pester-3-to-Pester-4](https://github.com/pester/Pester/wiki/Migrating-from-Pester-3-to-Pester-4)
+[https://pester.dev/docs/migrations/v3-to-v4](https://pester.dev/docs/migrations/v3-to-v4)
 
 [https://github.com/pester/Pester/issues/880](https://github.com/pester/Pester/issues/880)

--- a/docs/commands/BeforeAll.mdx
+++ b/docs/commands/BeforeAll.mdx
@@ -68,6 +68,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[https://github.com/pester/Pester/wiki/BeforeEach-and-AfterEach](https://github.com/pester/Pester/wiki/BeforeEach-and-AfterEach)
-
-[about_BeforeEach_AfterEach]()
+[https://pester.dev/docs/commands/BeforeAll](https://pester.dev/docs/commands/BeforeAll)

--- a/docs/commands/BeforeAll.mdx
+++ b/docs/commands/BeforeAll.mdx
@@ -68,4 +68,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[https://pester.dev/docs/commands/BeforeAll](https://pester.dev/docs/commands/BeforeAll)
+[https://pester.dev/docs/commands/AfterAll](https://pester.dev/docs/commands/AfterAll)

--- a/docs/commands/BeforeEach.mdx
+++ b/docs/commands/BeforeEach.mdx
@@ -71,6 +71,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[https://github.com/pester/Pester/wiki/BeforeEach-and-AfterEach](https://github.com/pester/Pester/wiki/BeforeEach-and-AfterEach)
-
-[about_BeforeEach_AfterEach]()
+[https://pester.dev/docs/commands/BeforeEach](https://pester.dev/docs/commands/BeforeEach)

--- a/docs/commands/BeforeEach.mdx
+++ b/docs/commands/BeforeEach.mdx
@@ -71,4 +71,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[https://pester.dev/docs/commands/BeforeEach](https://pester.dev/docs/commands/BeforeEach)
+[https://pester.dev/docs/commands/AfterEach](https://pester.dev/docs/commands/AfterEach)

--- a/docs/commands/BeforeEachFeature.mdx
+++ b/docs/commands/BeforeEachFeature.mdx
@@ -93,8 +93,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[AfterEachFeature]()
+[https://pester.dev/docs/commands/AfterEachFeature](https://pester.dev/docs/commands/AfterEachFeature)
 
-[BeforeEachScenario]()
+[https://pester.dev/docs/commands/BeforeEachScenario](https://pester.dev/docs/commands/BeforeEachScenario)
 
-[AfterEachScenario]()
+[https://pester.dev/docs/commands/AfterEachScenario](https://pester.dev/docs/commands/AfterEachScenario)

--- a/docs/commands/BeforeEachFeature.mdx
+++ b/docs/commands/BeforeEachFeature.mdx
@@ -93,6 +93,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[AfterEachFeature
-BeforeEachScenario
-AfterEachScenario]()
+[AfterEachFeature]()
+
+[BeforeEachScenario]()
+
+[AfterEachScenario]()

--- a/docs/commands/BeforeEachScenario.mdx
+++ b/docs/commands/BeforeEachScenario.mdx
@@ -95,6 +95,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[AfterEachFeature
-BeforeEachScenario
-AfterEachScenario]()
+[AfterEachFeature]()
+
+[BeforeEachScenario]()
+
+[AfterEachScenario]()

--- a/docs/commands/BeforeEachScenario.mdx
+++ b/docs/commands/BeforeEachScenario.mdx
@@ -95,8 +95,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[AfterEachFeature]()
+[https://pester.dev/docs/commands/AfterEachScenario](https://pester.dev/docs/commands/AfterEachScenario)
 
-[BeforeEachScenario]()
+[https://pester.dev/docs/commands/BeforeEachFeature](https://pester.dev/docs/commands/BeforeEachFeature)
 
-[AfterEachScenario]()
+[https://pester.dev/docs/commands/AfterEachFeature](https://pester.dev/docs/commands/AfterEachFeature)

--- a/docs/commands/Context.mdx
+++ b/docs/commands/Context.mdx
@@ -126,12 +126,18 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[https://github.com/pester/Pester/wiki/Context](https://github.com/pester/Pester/wiki/Context)
+[https://pester.dev/docs/commands/Context](https://pester.dev/docs/commands/Context)
 
-[Describe
-It
-BeforeEach
-AfterEach
-about_Should
-about_Mocking
-about_TestDrive]()
+[Describe]()
+
+[It]()
+
+[BeforeEach]()
+
+[AfterEach]()
+
+[about_Should]()
+
+[about_Mocking]()
+
+[about_TestDrive]()

--- a/docs/commands/Context.mdx
+++ b/docs/commands/Context.mdx
@@ -126,18 +126,16 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[https://pester.dev/docs/commands/Context](https://pester.dev/docs/commands/Context)
+[https://pester.dev/docs/commands/Describe](https://pester.dev/docs/commands/Describe)
 
-[Describe]()
+[https://pester.dev/docs/commands/It](https://pester.dev/docs/commands/It)
 
-[It]()
+[https://pester.dev/docs/commands/BeforeEach](https://pester.dev/docs/commands/BeforeEach)
 
-[BeforeEach]()
+[https://pester.dev/docs/commands/AfterEach](https://pester.dev/docs/commands/AfterEach)
 
-[AfterEach]()
+[https://pester.dev/docs/commands/Should](https://pester.dev/docs/commands/Should)
 
-[about_Should]()
+[https://pester.dev/docs/usage/mocking](https://pester.dev/docs/usage/mocking)
 
-[about_Mocking]()
-
-[about_TestDrive]()
+[https://pester.dev/docs/usage/testdrive](https://pester.dev/docs/usage/testdrive)

--- a/docs/commands/Describe.mdx
+++ b/docs/commands/Describe.mdx
@@ -136,9 +136,16 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[It
-Context
-Invoke-Pester
-about_Should
-about_Mocking
-about_TestDrive]()
+[https://pester.dev/docs/commands/Describe](https://pester.dev/docs/commands/Describe)
+
+[It]()
+
+[Context]()
+
+[Invoke-Pester]()
+
+[about_Should]()
+
+[about_Mocking]()
+
+[about_TestDrive]()

--- a/docs/commands/Describe.mdx
+++ b/docs/commands/Describe.mdx
@@ -136,16 +136,14 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[https://pester.dev/docs/commands/Describe](https://pester.dev/docs/commands/Describe)
+[https://pester.dev/docs/commands/It](https://pester.dev/docs/commands/It)
 
-[It]()
+[https://pester.dev/docs/commands/Context](https://pester.dev/docs/commands/Context)
 
-[Context]()
+[https://pester.dev/docs/commands/Invoke-Pester](https://pester.dev/docs/commands/Invoke-Pester)
 
-[Invoke-Pester]()
+[https://pester.dev/docs/commands/Should](https://pester.dev/docs/commands/Should)
 
-[about_Should]()
+[https://pester.dev/docs/usage/mocking](https://pester.dev/docs/usage/mocking)
 
-[about_Mocking]()
-
-[about_TestDrive]()
+[https://pester.dev/docs/usage/testdrive](https://pester.dev/docs/usage/testdrive)

--- a/docs/commands/Get-ShouldOperator.mdx
+++ b/docs/commands/Get-ShouldOperator.mdx
@@ -83,6 +83,6 @@ standard PowerShell discovery patterns (like `Get-Help Should -Parameter *`).
 
 ## RELATED LINKS
 
-[https://github.com/Pester/Pester
-about_Should](https://github.com/Pester/Pester
-about_Should)
+[https://pester.dev/docs/commands/Get-ShouldOperator](https://pester.dev/docs/commands/Get-ShouldOperator)
+
+[about_Should]()

--- a/docs/commands/Get-ShouldOperator.mdx
+++ b/docs/commands/Get-ShouldOperator.mdx
@@ -83,6 +83,4 @@ standard PowerShell discovery patterns (like `Get-Help Should -Parameter *`).
 
 ## RELATED LINKS
 
-[https://pester.dev/docs/commands/Get-ShouldOperator](https://pester.dev/docs/commands/Get-ShouldOperator)
-
-[about_Should]()
+[https://pester.dev/docs/commands/Should](https://pester.dev/docs/commands/Should)

--- a/docs/commands/Get-TestDriveItem.mdx
+++ b/docs/commands/Get-TestDriveItem.mdx
@@ -73,6 +73,6 @@ Accept wildcard characters: False
 
 ## RELATED LINKS
 
-[https://github.com/pester/Pester/wiki/TestDrive
-about_TestDrive](https://github.com/pester/Pester/wiki/TestDrive
-about_TestDrive)
+[https://pester.dev/docs/usage/testdrive](https://pester.dev/docs/usage/testdrive)
+
+[about_TestDrive]()

--- a/docs/commands/Get-TestDriveItem.mdx
+++ b/docs/commands/Get-TestDriveItem.mdx
@@ -74,5 +74,3 @@ Accept wildcard characters: False
 ## RELATED LINKS
 
 [https://pester.dev/docs/usage/testdrive](https://pester.dev/docs/usage/testdrive)
-
-[about_TestDrive]()

--- a/docs/commands/GherkinStep.mdx
+++ b/docs/commands/GherkinStep.mdx
@@ -138,8 +138,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[about_gherkin]()
-
-[Invoke-GherkinStep
-
-https://sites.google.com/site/unclebobconsultingllc/the-truth-about-bdd]()
+[https://sites.google.com/site/unclebobconsultingllc/the-truth-about-bdd](https://sites.google.com/site/unclebobconsultingllc/the-truth-about-bdd)

--- a/docs/commands/GherkinStep.mdx
+++ b/docs/commands/GherkinStep.mdx
@@ -138,6 +138,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[about_gherkin
-Invoke-GherkinStep
+[about_gherkin]()
+
+[Invoke-GherkinStep
+
 https://sites.google.com/site/unclebobconsultingllc/the-truth-about-bdd]()

--- a/docs/commands/In.mdx
+++ b/docs/commands/In.mdx
@@ -84,5 +84,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-
-[https://pester.dev/docs/commands/In](https://pester.dev/docs/commands/In)

--- a/docs/commands/In.mdx
+++ b/docs/commands/In.mdx
@@ -85,4 +85,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[https://github.com/pester/Pester/wiki/In](https://github.com/pester/Pester/wiki/In)
+[https://pester.dev/docs/commands/In](https://pester.dev/docs/commands/In)

--- a/docs/commands/Invoke-Gherkin.mdx
+++ b/docs/commands/Invoke-Gherkin.mdx
@@ -387,5 +387,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## RELATED LINKS
 
 [Invoke-Pester
-https://kevinmarquette.github.io/2017-03-17-Powershell-Gherkin-specification-validation/
-https://kevinmarquette.github.io/2017-04-30-Powershell-Gherkin-advanced-features/]()
+https://kevinmarquette.github.io/2017-03-17-Powershell-Gherkin-specification-validation/]()
+
+[https://kevinmarquette.github.io/2017-04-30-Powershell-Gherkin-advanced-features/](https://kevinmarquette.github.io/2017-04-30-Powershell-Gherkin-advanced-features/)

--- a/docs/commands/Invoke-Pester.mdx
+++ b/docs/commands/Invoke-Pester.mdx
@@ -22,8 +22,8 @@ Runs Pester tests
 ```powershell
 Invoke-Pester [[-Script] <Object[]>] [[-TestName] <String[]>] [-EnableExit] [[-Tag] <String[]>]
  [-ExcludeTag <String[]>] [-PassThru] [-CodeCoverage <Object[]>] [-CodeCoverageOutputFile <String>]
- [-CodeCoverageOutputFileFormat <String>] [-Strict] [-Quiet] [-PesterOption <Object>] [-Show <OutputTypes>]
- [<CommonParameters>]
+ [-CodeCoverageOutputFileEncoding <String>] [-CodeCoverageOutputFileFormat <String>] [-Strict] [-Quiet]
+ [-PesterOption <Object>] [-Show <OutputTypes>] [<CommonParameters>]
 ```
 
 ### NewOutputSet
@@ -31,8 +31,9 @@ Invoke-Pester [[-Script] <Object[]>] [[-TestName] <String[]>] [-EnableExit] [[-T
 ```powershell
 Invoke-Pester [[-Script] <Object[]>] [[-TestName] <String[]>] [-EnableExit] [[-Tag] <String[]>]
  [-ExcludeTag <String[]>] [-PassThru] [-CodeCoverage <Object[]>] [-CodeCoverageOutputFile <String>]
- [-CodeCoverageOutputFileFormat <String>] [-Strict] -OutputFile <String> [-OutputFormat <String>] [-Quiet]
- [-PesterOption <Object>] [-Show <OutputTypes>] [<CommonParameters>]
+ [-CodeCoverageOutputFileEncoding <String>] [-CodeCoverageOutputFileFormat <String>] [-Strict]
+ -OutputFile <String> [-OutputFormat <String>] [-Quiet] [-PesterOption <Object>] [-Show <OutputTypes>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -492,6 +493,27 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -CodeCoverageOutputFileEncoding
+
+The encoding in which Invoke-Pester will save the code coverage results file
+as.
+Defaults to 'utf8'.
+
+Supported encodings in the respective PowerShell version are the same as
+those supported by the cmdlet Out-File in that PowerShell version.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: Utf8
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/commands/Invoke-Pester.mdx
+++ b/docs/commands/Invoke-Pester.mdx
@@ -685,8 +685,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[https://pester.dev/docs/commands/Invoke-Pester](https://pester.dev/docs/commands/Invoke-Pester)
-
 [https://pester.dev/docs/commands/Describe](https://pester.dev/docs/commands/Describe)
 
 [https://pester.dev/docs/commands/New-PesterOption](https://pester.dev/docs/commands/New-PesterOption)

--- a/docs/commands/It.mdx
+++ b/docs/commands/It.mdx
@@ -224,9 +224,12 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[https://github.com/pester/Pester/wiki/It](https://github.com/pester/Pester/wiki/It)
+[https://pester.dev/docs/commands/It](https://pester.dev/docs/commands/It)
 
-[Describe
-Context
-Set-TestInconclusive
-about_should]()
+[Describe]()
+
+[Context]()
+
+[Set-TestInconclusive]()
+
+[about_should]()

--- a/docs/commands/It.mdx
+++ b/docs/commands/It.mdx
@@ -224,12 +224,10 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[https://pester.dev/docs/commands/It](https://pester.dev/docs/commands/It)
+[https://pester.dev/docs/commands/Describe](https://pester.dev/docs/commands/Describe)
 
-[Describe]()
+[https://pester.dev/docs/commands/Context](https://pester.dev/docs/commands/Context)
 
-[Context]()
+[https://pester.dev/docs/commands/Set-TestInconclusive](https://pester.dev/docs/commands/Set-TestInconclusive)
 
-[Set-TestInconclusive]()
-
-[about_should]()
+[https://pester.dev/docs/commands/Should](https://pester.dev/docs/commands/Should)

--- a/docs/commands/Mock.mdx
+++ b/docs/commands/Mock.mdx
@@ -342,18 +342,16 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[https://pester.dev/docs/commands/Mock](https://pester.dev/docs/commands/Mock)
+[https://pester.dev/docs/commands/Assert-MockCalled](https://pester.dev/docs/commands/Assert-MockCalled)
 
-[Assert-MockCalled]()
+[https://pester.dev/docs/commands/Assert-VerifiableMock](https://pester.dev/docs/commands/Assert-VerifiableMock)
 
-[Assert-VerifiableMock]()
+[https://pester.dev/docs/commands/Describe](https://pester.dev/docs/commands/Describe)
 
-[Describe]()
+[https://pester.dev/docs/commands/Context](https://pester.dev/docs/commands/Context)
 
-[Context]()
+[https://pester.dev/docs/commands/It](https://pester.dev/docs/commands/It)
 
-[It]()
+[https://pester.dev/docs/commands/Should](https://pester.dev/docs/commands/Should)
 
-[about_Should]()
-
-[about_Mocking]()
+[https://pester.dev/docs/usage/mocking](https://pester.dev/docs/usage/mocking)

--- a/docs/commands/Mock.mdx
+++ b/docs/commands/Mock.mdx
@@ -342,10 +342,18 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Assert-MockCalled
-Assert-VerifiableMock
-Describe
-Context
-It
-about_Should
-about_Mocking]()
+[https://pester.dev/docs/commands/Mock](https://pester.dev/docs/commands/Mock)
+
+[Assert-MockCalled]()
+
+[Assert-VerifiableMock]()
+
+[Describe]()
+
+[Context]()
+
+[It]()
+
+[about_Should]()
+
+[about_Mocking]()

--- a/docs/commands/New-Fixture.mdx
+++ b/docs/commands/New-Fixture.mdx
@@ -124,14 +124,10 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[https://pester.dev/docs/commands/New-Fixture](https://pester.dev/docs/commands/New-Fixture)
+[https://pester.dev/docs/commands/Describe](https://pester.dev/docs/commands/Describe)
 
-[Describe]()
+[https://pester.dev/docs/commands/Context](https://pester.dev/docs/commands/Context)
 
-[Context]()
+[https://pester.dev/docs/commands/It](https://pester.dev/docs/commands/It)
 
-[It]()
-
-[about_Pester]()
-
-[about_Should]()
+[https://pester.dev/docs/commands/Should](https://pester.dev/docs/commands/Should)

--- a/docs/commands/New-Fixture.mdx
+++ b/docs/commands/New-Fixture.mdx
@@ -124,8 +124,14 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[Describe
-Context
-It
-about_Pester
-about_Should]()
+[https://pester.dev/docs/commands/New-Fixture](https://pester.dev/docs/commands/New-Fixture)
+
+[Describe]()
+
+[Context]()
+
+[It]()
+
+[about_Pester]()
+
+[about_Should]()

--- a/docs/commands/New-PesterOption.mdx
+++ b/docs/commands/New-PesterOption.mdx
@@ -144,6 +144,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[https://pester.dev/docs/commands/New-PesterOption](https://pester.dev/docs/commands/New-PesterOption)
-
 [https://pester.dev/docs/commands/Invoke-Pester](https://pester.dev/docs/commands/Invoke-Pester)

--- a/docs/commands/Set-TestInconclusive.mdx
+++ b/docs/commands/Set-TestInconclusive.mdx
@@ -77,5 +77,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-
-[https://pester.dev/docs/commands/Set-TestInconclusive](https://pester.dev/docs/commands/Set-TestInconclusive)

--- a/docs/commands/Set-TestInconclusive.mdx
+++ b/docs/commands/Set-TestInconclusive.mdx
@@ -78,4 +78,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[https://github.com/pester/Pester/wiki/Set%E2%80%90TestInconclusive](https://github.com/pester/Pester/wiki/Set%E2%80%90TestInconclusive)
+[https://pester.dev/docs/commands/Set-TestInconclusive](https://pester.dev/docs/commands/Set-TestInconclusive)

--- a/docs/commands/Should.mdx
+++ b/docs/commands/Should.mdx
@@ -887,9 +887,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-
-[https://pester.dev/docs/commands/Should](https://pester.dev/docs/commands/Should)
-
-[about_Should]()
-
-[about_Pester]()

--- a/docs/commands/Should.mdx
+++ b/docs/commands/Should.mdx
@@ -888,7 +888,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[https://github.com/pester/Pester/wiki/Should](https://github.com/pester/Pester/wiki/Should)
+[https://pester.dev/docs/commands/Should](https://pester.dev/docs/commands/Should)
 
-[about_Should
-about_Pester]()
+[about_Should]()
+
+[about_Pester]()


### PR DESCRIPTION
Auto-generated command reference using the link-fixes done in Pester source code PR https://github.com/pester/Pester/pull/1432.