### PR TITLE
Enables Edit this Page buttons

### DIFF
--- a/docs/commands/Add-AssertionOperator.mdx
+++ b/docs/commands/Add-AssertionOperator.mdx
@@ -161,6 +161,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-## ADDITIONAL INFORMATION
+## EDIT THIS PAGE
 
-This page was auto-generated using the [Pester](https://github.com/pester/pester) Get-Help documentation for this specific function.
+This page was auto-generated using Pester's comment based help. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.

--- a/docs/commands/Add-AssertionOperator.mdx
+++ b/docs/commands/Add-AssertionOperator.mdx
@@ -9,6 +9,7 @@ keywords:
   - Documentation
 hide_title: false
 hide_table_of_contents: false
+custom_edit_url: null
 ---
 
 ## SYNOPSIS

--- a/docs/commands/Add-AssertionOperator.mdx
+++ b/docs/commands/Add-AssertionOperator.mdx
@@ -160,3 +160,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
+
+## ADDITIONAL INFORMATION
+
+This page was auto-generated using the [Pester](https://github.com/pester/pester) Get-Help documentation for this specific function.

--- a/docs/commands/AfterAll.mdx
+++ b/docs/commands/AfterAll.mdx
@@ -9,6 +9,7 @@ keywords:
   - Documentation
 hide_title: false
 hide_table_of_contents: false
+custom_edit_url: null
 ---
 
 ## SYNOPSIS

--- a/docs/commands/AfterAll.mdx
+++ b/docs/commands/AfterAll.mdx
@@ -70,3 +70,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## RELATED LINKS
 
 [https://pester.dev/docs/commands/BeforeAll](https://pester.dev/docs/commands/BeforeAll)
+
+## ADDITIONAL INFORMATION
+
+This page was auto-generated using the [Pester](https://github.com/pester/pester) Get-Help documentation for this specific function.

--- a/docs/commands/AfterAll.mdx
+++ b/docs/commands/AfterAll.mdx
@@ -71,6 +71,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [https://pester.dev/docs/commands/BeforeAll](https://pester.dev/docs/commands/BeforeAll)
 
-## ADDITIONAL INFORMATION
+## EDIT THIS PAGE
 
-This page was auto-generated using the [Pester](https://github.com/pester/pester) Get-Help documentation for this specific function.
+This page was auto-generated using Pester's comment based help. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.

--- a/docs/commands/AfterEach.mdx
+++ b/docs/commands/AfterEach.mdx
@@ -9,6 +9,7 @@ keywords:
   - Documentation
 hide_title: false
 hide_table_of_contents: false
+custom_edit_url: null
 ---
 
 ## SYNOPSIS

--- a/docs/commands/AfterEach.mdx
+++ b/docs/commands/AfterEach.mdx
@@ -73,3 +73,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## RELATED LINKS
 
 [https://pester.dev/docs/commands/BeforeEach](https://pester.dev/docs/commands/BeforeEach)
+
+## ADDITIONAL INFORMATION
+
+This page was auto-generated using the [Pester](https://github.com/pester/pester) Get-Help documentation for this specific function.

--- a/docs/commands/AfterEach.mdx
+++ b/docs/commands/AfterEach.mdx
@@ -74,6 +74,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [https://pester.dev/docs/commands/BeforeEach](https://pester.dev/docs/commands/BeforeEach)
 
-## ADDITIONAL INFORMATION
+## EDIT THIS PAGE
 
-This page was auto-generated using the [Pester](https://github.com/pester/pester) Get-Help documentation for this specific function.
+This page was auto-generated using Pester's comment based help. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.

--- a/docs/commands/AfterEachFeature.mdx
+++ b/docs/commands/AfterEachFeature.mdx
@@ -9,6 +9,7 @@ keywords:
   - Documentation
 hide_title: false
 hide_table_of_contents: false
+custom_edit_url: null
 ---
 
 ## SYNOPSIS

--- a/docs/commands/AfterEachFeature.mdx
+++ b/docs/commands/AfterEachFeature.mdx
@@ -100,6 +100,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [https://pester.dev/docs/commands/AfterEachScenario](https://pester.dev/docs/commands/AfterEachScenario)
 
-## ADDITIONAL INFORMATION
+## EDIT THIS PAGE
 
-This page was auto-generated using the [Pester](https://github.com/pester/pester) Get-Help documentation for this specific function.
+This page was auto-generated using Pester's comment based help. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.

--- a/docs/commands/AfterEachFeature.mdx
+++ b/docs/commands/AfterEachFeature.mdx
@@ -99,3 +99,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [https://pester.dev/docs/commands/BeforeEachScenario](https://pester.dev/docs/commands/BeforeEachScenario)
 
 [https://pester.dev/docs/commands/AfterEachScenario](https://pester.dev/docs/commands/AfterEachScenario)
+
+## ADDITIONAL INFORMATION
+
+This page was auto-generated using the [Pester](https://github.com/pester/pester) Get-Help documentation for this specific function.

--- a/docs/commands/AfterEachScenario.mdx
+++ b/docs/commands/AfterEachScenario.mdx
@@ -99,3 +99,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [https://pester.dev/docs/commands/BeforeEachFeature](https://pester.dev/docs/commands/BeforeEachFeature)
 
 [https://pester.dev/docs/commands/AfterEachFeature](https://pester.dev/docs/commands/AfterEachFeature)
+
+## ADDITIONAL INFORMATION
+
+This page was auto-generated using the [Pester](https://github.com/pester/pester) Get-Help documentation for this specific function.

--- a/docs/commands/AfterEachScenario.mdx
+++ b/docs/commands/AfterEachScenario.mdx
@@ -100,6 +100,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [https://pester.dev/docs/commands/AfterEachFeature](https://pester.dev/docs/commands/AfterEachFeature)
 
-## ADDITIONAL INFORMATION
+## EDIT THIS PAGE
 
-This page was auto-generated using the [Pester](https://github.com/pester/pester) Get-Help documentation for this specific function.
+This page was auto-generated using Pester's comment based help. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.

--- a/docs/commands/AfterEachScenario.mdx
+++ b/docs/commands/AfterEachScenario.mdx
@@ -9,6 +9,7 @@ keywords:
   - Documentation
 hide_title: false
 hide_table_of_contents: false
+custom_edit_url: null
 ---
 
 ## SYNOPSIS

--- a/docs/commands/Assert-MockCalled.mdx
+++ b/docs/commands/Assert-MockCalled.mdx
@@ -311,3 +311,7 @@ In other words, Assert-MockCalled can only be used to check for calls to the moc
 to the original.
 
 ## RELATED LINKS
+
+## ADDITIONAL INFORMATION
+
+This page was auto-generated using the [Pester](https://github.com/pester/pester) Get-Help documentation for this specific function.

--- a/docs/commands/Assert-MockCalled.mdx
+++ b/docs/commands/Assert-MockCalled.mdx
@@ -9,6 +9,7 @@ keywords:
   - Documentation
 hide_title: false
 hide_table_of_contents: false
+custom_edit_url: null
 ---
 
 ## SYNOPSIS

--- a/docs/commands/Assert-MockCalled.mdx
+++ b/docs/commands/Assert-MockCalled.mdx
@@ -312,6 +312,6 @@ to the original.
 
 ## RELATED LINKS
 
-## ADDITIONAL INFORMATION
+## EDIT THIS PAGE
 
-This page was auto-generated using the [Pester](https://github.com/pester/pester) Get-Help documentation for this specific function.
+This page was auto-generated using Pester's comment based help. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.

--- a/docs/commands/Assert-VerifiableMock.mdx
+++ b/docs/commands/Assert-VerifiableMock.mdx
@@ -9,6 +9,7 @@ keywords:
   - Documentation
 hide_title: false
 hide_table_of_contents: false
+custom_edit_url: null
 ---
 
 ## SYNOPSIS

--- a/docs/commands/Assert-VerifiableMock.mdx
+++ b/docs/commands/Assert-VerifiableMock.mdx
@@ -75,3 +75,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
+
+## ADDITIONAL INFORMATION
+
+This page was auto-generated using the [Pester](https://github.com/pester/pester) Get-Help documentation for this specific function.

--- a/docs/commands/Assert-VerifiableMock.mdx
+++ b/docs/commands/Assert-VerifiableMock.mdx
@@ -76,6 +76,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-## ADDITIONAL INFORMATION
+## EDIT THIS PAGE
 
-This page was auto-generated using the [Pester](https://github.com/pester/pester) Get-Help documentation for this specific function.
+This page was auto-generated using Pester's comment based help. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.

--- a/docs/commands/Assert-VerifiableMocks.mdx
+++ b/docs/commands/Assert-VerifiableMocks.mdx
@@ -9,6 +9,7 @@ keywords:
   - Documentation
 hide_title: false
 hide_table_of_contents: false
+custom_edit_url: null
 ---
 
 ## SYNOPSIS

--- a/docs/commands/Assert-VerifiableMocks.mdx
+++ b/docs/commands/Assert-VerifiableMocks.mdx
@@ -57,6 +57,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [https://github.com/pester/Pester/issues/880](https://github.com/pester/Pester/issues/880)
 
-## ADDITIONAL INFORMATION
+## EDIT THIS PAGE
 
-This page was auto-generated using the [Pester](https://github.com/pester/pester) Get-Help documentation for this specific function.
+This page was auto-generated using Pester's comment based help. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.

--- a/docs/commands/Assert-VerifiableMocks.mdx
+++ b/docs/commands/Assert-VerifiableMocks.mdx
@@ -56,3 +56,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [https://pester.dev/docs/migrations/v3-to-v4](https://pester.dev/docs/migrations/v3-to-v4)
 
 [https://github.com/pester/Pester/issues/880](https://github.com/pester/Pester/issues/880)
+
+## ADDITIONAL INFORMATION
+
+This page was auto-generated using the [Pester](https://github.com/pester/pester) Get-Help documentation for this specific function.

--- a/docs/commands/BeforeAll.mdx
+++ b/docs/commands/BeforeAll.mdx
@@ -9,6 +9,7 @@ keywords:
   - Documentation
 hide_title: false
 hide_table_of_contents: false
+custom_edit_url: null
 ---
 
 ## SYNOPSIS

--- a/docs/commands/BeforeAll.mdx
+++ b/docs/commands/BeforeAll.mdx
@@ -71,6 +71,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [https://pester.dev/docs/commands/AfterAll](https://pester.dev/docs/commands/AfterAll)
 
-## ADDITIONAL INFORMATION
+## EDIT THIS PAGE
 
-This page was auto-generated using the [Pester](https://github.com/pester/pester) Get-Help documentation for this specific function.
+This page was auto-generated using Pester's comment based help. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.

--- a/docs/commands/BeforeAll.mdx
+++ b/docs/commands/BeforeAll.mdx
@@ -70,3 +70,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## RELATED LINKS
 
 [https://pester.dev/docs/commands/AfterAll](https://pester.dev/docs/commands/AfterAll)
+
+## ADDITIONAL INFORMATION
+
+This page was auto-generated using the [Pester](https://github.com/pester/pester) Get-Help documentation for this specific function.

--- a/docs/commands/BeforeEach.mdx
+++ b/docs/commands/BeforeEach.mdx
@@ -74,6 +74,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [https://pester.dev/docs/commands/AfterEach](https://pester.dev/docs/commands/AfterEach)
 
-## ADDITIONAL INFORMATION
+## EDIT THIS PAGE
 
-This page was auto-generated using the [Pester](https://github.com/pester/pester) Get-Help documentation for this specific function.
+This page was auto-generated using Pester's comment based help. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.

--- a/docs/commands/BeforeEach.mdx
+++ b/docs/commands/BeforeEach.mdx
@@ -73,3 +73,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## RELATED LINKS
 
 [https://pester.dev/docs/commands/AfterEach](https://pester.dev/docs/commands/AfterEach)
+
+## ADDITIONAL INFORMATION
+
+This page was auto-generated using the [Pester](https://github.com/pester/pester) Get-Help documentation for this specific function.

--- a/docs/commands/BeforeEach.mdx
+++ b/docs/commands/BeforeEach.mdx
@@ -9,6 +9,7 @@ keywords:
   - Documentation
 hide_title: false
 hide_table_of_contents: false
+custom_edit_url: null
 ---
 
 ## SYNOPSIS

--- a/docs/commands/BeforeEachFeature.mdx
+++ b/docs/commands/BeforeEachFeature.mdx
@@ -9,6 +9,7 @@ keywords:
   - Documentation
 hide_title: false
 hide_table_of_contents: false
+custom_edit_url: null
 ---
 
 ## SYNOPSIS

--- a/docs/commands/BeforeEachFeature.mdx
+++ b/docs/commands/BeforeEachFeature.mdx
@@ -100,6 +100,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [https://pester.dev/docs/commands/AfterEachScenario](https://pester.dev/docs/commands/AfterEachScenario)
 
-## ADDITIONAL INFORMATION
+## EDIT THIS PAGE
 
-This page was auto-generated using the [Pester](https://github.com/pester/pester) Get-Help documentation for this specific function.
+This page was auto-generated using Pester's comment based help. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.

--- a/docs/commands/BeforeEachFeature.mdx
+++ b/docs/commands/BeforeEachFeature.mdx
@@ -99,3 +99,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [https://pester.dev/docs/commands/BeforeEachScenario](https://pester.dev/docs/commands/BeforeEachScenario)
 
 [https://pester.dev/docs/commands/AfterEachScenario](https://pester.dev/docs/commands/AfterEachScenario)
+
+## ADDITIONAL INFORMATION
+
+This page was auto-generated using the [Pester](https://github.com/pester/pester) Get-Help documentation for this specific function.

--- a/docs/commands/BeforeEachScenario.mdx
+++ b/docs/commands/BeforeEachScenario.mdx
@@ -9,6 +9,7 @@ keywords:
   - Documentation
 hide_title: false
 hide_table_of_contents: false
+custom_edit_url: null
 ---
 
 ## SYNOPSIS

--- a/docs/commands/BeforeEachScenario.mdx
+++ b/docs/commands/BeforeEachScenario.mdx
@@ -102,6 +102,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [https://pester.dev/docs/commands/AfterEachFeature](https://pester.dev/docs/commands/AfterEachFeature)
 
-## ADDITIONAL INFORMATION
+## EDIT THIS PAGE
 
-This page was auto-generated using the [Pester](https://github.com/pester/pester) Get-Help documentation for this specific function.
+This page was auto-generated using Pester's comment based help. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.

--- a/docs/commands/BeforeEachScenario.mdx
+++ b/docs/commands/BeforeEachScenario.mdx
@@ -101,3 +101,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [https://pester.dev/docs/commands/BeforeEachFeature](https://pester.dev/docs/commands/BeforeEachFeature)
 
 [https://pester.dev/docs/commands/AfterEachFeature](https://pester.dev/docs/commands/AfterEachFeature)
+
+## ADDITIONAL INFORMATION
+
+This page was auto-generated using the [Pester](https://github.com/pester/pester) Get-Help documentation for this specific function.

--- a/docs/commands/Context.mdx
+++ b/docs/commands/Context.mdx
@@ -9,6 +9,7 @@ keywords:
   - Documentation
 hide_title: false
 hide_table_of_contents: false
+custom_edit_url: null
 ---
 
 ## SYNOPSIS

--- a/docs/commands/Context.mdx
+++ b/docs/commands/Context.mdx
@@ -141,6 +141,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [https://pester.dev/docs/usage/testdrive](https://pester.dev/docs/usage/testdrive)
 
-## ADDITIONAL INFORMATION
+## EDIT THIS PAGE
 
-This page was auto-generated using the [Pester](https://github.com/pester/pester) Get-Help documentation for this specific function.
+This page was auto-generated using Pester's comment based help. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.

--- a/docs/commands/Context.mdx
+++ b/docs/commands/Context.mdx
@@ -140,3 +140,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [https://pester.dev/docs/usage/mocking](https://pester.dev/docs/usage/mocking)
 
 [https://pester.dev/docs/usage/testdrive](https://pester.dev/docs/usage/testdrive)
+
+## ADDITIONAL INFORMATION
+
+This page was auto-generated using the [Pester](https://github.com/pester/pester) Get-Help documentation for this specific function.

--- a/docs/commands/Describe.mdx
+++ b/docs/commands/Describe.mdx
@@ -149,6 +149,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [https://pester.dev/docs/usage/testdrive](https://pester.dev/docs/usage/testdrive)
 
-## ADDITIONAL INFORMATION
+## EDIT THIS PAGE
 
-This page was auto-generated using the [Pester](https://github.com/pester/pester) Get-Help documentation for this specific function.
+This page was auto-generated using Pester's comment based help. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.

--- a/docs/commands/Describe.mdx
+++ b/docs/commands/Describe.mdx
@@ -9,6 +9,7 @@ keywords:
   - Documentation
 hide_title: false
 hide_table_of_contents: false
+custom_edit_url: null
 ---
 
 ## SYNOPSIS

--- a/docs/commands/Describe.mdx
+++ b/docs/commands/Describe.mdx
@@ -148,3 +148,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [https://pester.dev/docs/usage/mocking](https://pester.dev/docs/usage/mocking)
 
 [https://pester.dev/docs/usage/testdrive](https://pester.dev/docs/usage/testdrive)
+
+## ADDITIONAL INFORMATION
+
+This page was auto-generated using the [Pester](https://github.com/pester/pester) Get-Help documentation for this specific function.

--- a/docs/commands/Find-GherkinStep.mdx
+++ b/docs/commands/Find-GherkinStep.mdx
@@ -9,6 +9,7 @@ keywords:
   - Documentation
 hide_title: false
 hide_table_of_contents: false
+custom_edit_url: null
 ---
 
 ## SYNOPSIS

--- a/docs/commands/Find-GherkinStep.mdx
+++ b/docs/commands/Find-GherkinStep.mdx
@@ -84,3 +84,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
+
+## ADDITIONAL INFORMATION
+
+This page was auto-generated using the [Pester](https://github.com/pester/pester) Get-Help documentation for this specific function.

--- a/docs/commands/Find-GherkinStep.mdx
+++ b/docs/commands/Find-GherkinStep.mdx
@@ -85,6 +85,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-## ADDITIONAL INFORMATION
+## EDIT THIS PAGE
 
-This page was auto-generated using the [Pester](https://github.com/pester/pester) Get-Help documentation for this specific function.
+This page was auto-generated using Pester's comment based help. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.

--- a/docs/commands/Get-ShouldOperator.mdx
+++ b/docs/commands/Get-ShouldOperator.mdx
@@ -86,6 +86,6 @@ standard PowerShell discovery patterns (like `Get-Help Should -Parameter *`).
 
 [https://pester.dev/docs/commands/Should](https://pester.dev/docs/commands/Should)
 
-## ADDITIONAL INFORMATION
+## EDIT THIS PAGE
 
-This page was auto-generated using the [Pester](https://github.com/pester/pester) Get-Help documentation for this specific function.
+This page was auto-generated using Pester's comment based help. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.

--- a/docs/commands/Get-ShouldOperator.mdx
+++ b/docs/commands/Get-ShouldOperator.mdx
@@ -9,6 +9,7 @@ keywords:
   - Documentation
 hide_title: false
 hide_table_of_contents: false
+custom_edit_url: null
 ---
 
 ## SYNOPSIS

--- a/docs/commands/Get-ShouldOperator.mdx
+++ b/docs/commands/Get-ShouldOperator.mdx
@@ -85,3 +85,7 @@ standard PowerShell discovery patterns (like `Get-Help Should -Parameter *`).
 ## RELATED LINKS
 
 [https://pester.dev/docs/commands/Should](https://pester.dev/docs/commands/Should)
+
+## ADDITIONAL INFORMATION
+
+This page was auto-generated using the [Pester](https://github.com/pester/pester) Get-Help documentation for this specific function.

--- a/docs/commands/Get-TestDriveItem.mdx
+++ b/docs/commands/Get-TestDriveItem.mdx
@@ -9,6 +9,7 @@ keywords:
   - Documentation
 hide_title: false
 hide_table_of_contents: false
+custom_edit_url: null
 ---
 
 ## SYNOPSIS

--- a/docs/commands/Get-TestDriveItem.mdx
+++ b/docs/commands/Get-TestDriveItem.mdx
@@ -75,3 +75,7 @@ Accept wildcard characters: False
 ## RELATED LINKS
 
 [https://pester.dev/docs/usage/testdrive](https://pester.dev/docs/usage/testdrive)
+
+## ADDITIONAL INFORMATION
+
+This page was auto-generated using the [Pester](https://github.com/pester/pester) Get-Help documentation for this specific function.

--- a/docs/commands/Get-TestDriveItem.mdx
+++ b/docs/commands/Get-TestDriveItem.mdx
@@ -76,6 +76,6 @@ Accept wildcard characters: False
 
 [https://pester.dev/docs/usage/testdrive](https://pester.dev/docs/usage/testdrive)
 
-## ADDITIONAL INFORMATION
+## EDIT THIS PAGE
 
-This page was auto-generated using the [Pester](https://github.com/pester/pester) Get-Help documentation for this specific function.
+This page was auto-generated using Pester's comment based help. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.

--- a/docs/commands/GherkinStep.mdx
+++ b/docs/commands/GherkinStep.mdx
@@ -141,6 +141,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [https://sites.google.com/site/unclebobconsultingllc/the-truth-about-bdd](https://sites.google.com/site/unclebobconsultingllc/the-truth-about-bdd)
 
-## ADDITIONAL INFORMATION
+## EDIT THIS PAGE
 
-This page was auto-generated using the [Pester](https://github.com/pester/pester) Get-Help documentation for this specific function.
+This page was auto-generated using Pester's comment based help. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.

--- a/docs/commands/GherkinStep.mdx
+++ b/docs/commands/GherkinStep.mdx
@@ -140,3 +140,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## RELATED LINKS
 
 [https://sites.google.com/site/unclebobconsultingllc/the-truth-about-bdd](https://sites.google.com/site/unclebobconsultingllc/the-truth-about-bdd)
+
+## ADDITIONAL INFORMATION
+
+This page was auto-generated using the [Pester](https://github.com/pester/pester) Get-Help documentation for this specific function.

--- a/docs/commands/GherkinStep.mdx
+++ b/docs/commands/GherkinStep.mdx
@@ -9,6 +9,7 @@ keywords:
   - Documentation
 hide_title: false
 hide_table_of_contents: false
+custom_edit_url: null
 ---
 
 ## SYNOPSIS

--- a/docs/commands/In.mdx
+++ b/docs/commands/In.mdx
@@ -9,6 +9,7 @@ keywords:
   - Documentation
 hide_title: false
 hide_table_of_contents: false
+custom_edit_url: null
 ---
 
 ## SYNOPSIS

--- a/docs/commands/In.mdx
+++ b/docs/commands/In.mdx
@@ -86,6 +86,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-## ADDITIONAL INFORMATION
+## EDIT THIS PAGE
 
-This page was auto-generated using the [Pester](https://github.com/pester/pester) Get-Help documentation for this specific function.
+This page was auto-generated using Pester's comment based help. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.

--- a/docs/commands/In.mdx
+++ b/docs/commands/In.mdx
@@ -85,3 +85,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
+
+## ADDITIONAL INFORMATION
+
+This page was auto-generated using the [Pester](https://github.com/pester/pester) Get-Help documentation for this specific function.

--- a/docs/commands/InModuleScope.mdx
+++ b/docs/commands/InModuleScope.mdx
@@ -120,3 +120,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
+
+## ADDITIONAL INFORMATION
+
+This page was auto-generated using the [Pester](https://github.com/pester/pester) Get-Help documentation for this specific function.

--- a/docs/commands/InModuleScope.mdx
+++ b/docs/commands/InModuleScope.mdx
@@ -121,6 +121,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-## ADDITIONAL INFORMATION
+## EDIT THIS PAGE
 
-This page was auto-generated using the [Pester](https://github.com/pester/pester) Get-Help documentation for this specific function.
+This page was auto-generated using Pester's comment based help. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.

--- a/docs/commands/InModuleScope.mdx
+++ b/docs/commands/InModuleScope.mdx
@@ -9,6 +9,7 @@ keywords:
   - Documentation
 hide_title: false
 hide_table_of_contents: false
+custom_edit_url: null
 ---
 
 ## SYNOPSIS

--- a/docs/commands/Invoke-Gherkin.mdx
+++ b/docs/commands/Invoke-Gherkin.mdx
@@ -9,6 +9,7 @@ keywords:
   - Documentation
 hide_title: false
 hide_table_of_contents: false
+custom_edit_url: null
 ---
 
 ## SYNOPSIS

--- a/docs/commands/Invoke-Gherkin.mdx
+++ b/docs/commands/Invoke-Gherkin.mdx
@@ -392,6 +392,6 @@ https://kevinmarquette.github.io/2017-03-17-Powershell-Gherkin-specification-val
 
 [https://kevinmarquette.github.io/2017-04-30-Powershell-Gherkin-advanced-features/](https://kevinmarquette.github.io/2017-04-30-Powershell-Gherkin-advanced-features/)
 
-## ADDITIONAL INFORMATION
+## EDIT THIS PAGE
 
-This page was auto-generated using the [Pester](https://github.com/pester/pester) Get-Help documentation for this specific function.
+This page was auto-generated using Pester's comment based help. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.

--- a/docs/commands/Invoke-Gherkin.mdx
+++ b/docs/commands/Invoke-Gherkin.mdx
@@ -391,3 +391,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 https://kevinmarquette.github.io/2017-03-17-Powershell-Gherkin-specification-validation/]()
 
 [https://kevinmarquette.github.io/2017-04-30-Powershell-Gherkin-advanced-features/](https://kevinmarquette.github.io/2017-04-30-Powershell-Gherkin-advanced-features/)
+
+## ADDITIONAL INFORMATION
+
+This page was auto-generated using the [Pester](https://github.com/pester/pester) Get-Help documentation for this specific function.

--- a/docs/commands/Invoke-Pester.mdx
+++ b/docs/commands/Invoke-Pester.mdx
@@ -9,6 +9,7 @@ keywords:
   - Documentation
 hide_title: false
 hide_table_of_contents: false
+custom_edit_url: null
 ---
 
 ## SYNOPSIS

--- a/docs/commands/Invoke-Pester.mdx
+++ b/docs/commands/Invoke-Pester.mdx
@@ -690,6 +690,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [https://pester.dev/docs/commands/New-PesterOption](https://pester.dev/docs/commands/New-PesterOption)
 
-## ADDITIONAL INFORMATION
+## EDIT THIS PAGE
 
-This page was auto-generated using the [Pester](https://github.com/pester/pester) Get-Help documentation for this specific function.
+This page was auto-generated using Pester's comment based help. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.

--- a/docs/commands/Invoke-Pester.mdx
+++ b/docs/commands/Invoke-Pester.mdx
@@ -689,3 +689,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [https://pester.dev/docs/commands/Describe](https://pester.dev/docs/commands/Describe)
 
 [https://pester.dev/docs/commands/New-PesterOption](https://pester.dev/docs/commands/New-PesterOption)
+
+## ADDITIONAL INFORMATION
+
+This page was auto-generated using the [Pester](https://github.com/pester/pester) Get-Help documentation for this specific function.

--- a/docs/commands/It.mdx
+++ b/docs/commands/It.mdx
@@ -9,6 +9,7 @@ keywords:
   - Documentation
 hide_title: false
 hide_table_of_contents: false
+custom_edit_url: null
 ---
 
 ## SYNOPSIS

--- a/docs/commands/It.mdx
+++ b/docs/commands/It.mdx
@@ -232,3 +232,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [https://pester.dev/docs/commands/Set-TestInconclusive](https://pester.dev/docs/commands/Set-TestInconclusive)
 
 [https://pester.dev/docs/commands/Should](https://pester.dev/docs/commands/Should)
+
+## ADDITIONAL INFORMATION
+
+This page was auto-generated using the [Pester](https://github.com/pester/pester) Get-Help documentation for this specific function.

--- a/docs/commands/It.mdx
+++ b/docs/commands/It.mdx
@@ -233,6 +233,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [https://pester.dev/docs/commands/Should](https://pester.dev/docs/commands/Should)
 
-## ADDITIONAL INFORMATION
+## EDIT THIS PAGE
 
-This page was auto-generated using the [Pester](https://github.com/pester/pester) Get-Help documentation for this specific function.
+This page was auto-generated using Pester's comment based help. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.

--- a/docs/commands/Mock.mdx
+++ b/docs/commands/Mock.mdx
@@ -9,6 +9,7 @@ keywords:
   - Documentation
 hide_title: false
 hide_table_of_contents: false
+custom_edit_url: null
 ---
 
 ## SYNOPSIS

--- a/docs/commands/Mock.mdx
+++ b/docs/commands/Mock.mdx
@@ -356,3 +356,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [https://pester.dev/docs/commands/Should](https://pester.dev/docs/commands/Should)
 
 [https://pester.dev/docs/usage/mocking](https://pester.dev/docs/usage/mocking)
+
+## ADDITIONAL INFORMATION
+
+This page was auto-generated using the [Pester](https://github.com/pester/pester) Get-Help documentation for this specific function.

--- a/docs/commands/Mock.mdx
+++ b/docs/commands/Mock.mdx
@@ -357,6 +357,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [https://pester.dev/docs/usage/mocking](https://pester.dev/docs/usage/mocking)
 
-## ADDITIONAL INFORMATION
+## EDIT THIS PAGE
 
-This page was auto-generated using the [Pester](https://github.com/pester/pester) Get-Help documentation for this specific function.
+This page was auto-generated using Pester's comment based help. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.

--- a/docs/commands/New-Fixture.mdx
+++ b/docs/commands/New-Fixture.mdx
@@ -132,3 +132,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [https://pester.dev/docs/commands/It](https://pester.dev/docs/commands/It)
 
 [https://pester.dev/docs/commands/Should](https://pester.dev/docs/commands/Should)
+
+## ADDITIONAL INFORMATION
+
+This page was auto-generated using the [Pester](https://github.com/pester/pester) Get-Help documentation for this specific function.

--- a/docs/commands/New-Fixture.mdx
+++ b/docs/commands/New-Fixture.mdx
@@ -9,6 +9,7 @@ keywords:
   - Documentation
 hide_title: false
 hide_table_of_contents: false
+custom_edit_url: null
 ---
 
 ## SYNOPSIS

--- a/docs/commands/New-Fixture.mdx
+++ b/docs/commands/New-Fixture.mdx
@@ -133,6 +133,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [https://pester.dev/docs/commands/Should](https://pester.dev/docs/commands/Should)
 
-## ADDITIONAL INFORMATION
+## EDIT THIS PAGE
 
-This page was auto-generated using the [Pester](https://github.com/pester/pester) Get-Help documentation for this specific function.
+This page was auto-generated using Pester's comment based help. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.

--- a/docs/commands/New-MockObject.mdx
+++ b/docs/commands/New-MockObject.mdx
@@ -67,3 +67,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
+
+## ADDITIONAL INFORMATION
+
+This page was auto-generated using the [Pester](https://github.com/pester/pester) Get-Help documentation for this specific function.

--- a/docs/commands/New-MockObject.mdx
+++ b/docs/commands/New-MockObject.mdx
@@ -9,6 +9,7 @@ keywords:
   - Documentation
 hide_title: false
 hide_table_of_contents: false
+custom_edit_url: null
 ---
 
 ## SYNOPSIS

--- a/docs/commands/New-MockObject.mdx
+++ b/docs/commands/New-MockObject.mdx
@@ -68,6 +68,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-## ADDITIONAL INFORMATION
+## EDIT THIS PAGE
 
-This page was auto-generated using the [Pester](https://github.com/pester/pester) Get-Help documentation for this specific function.
+This page was auto-generated using Pester's comment based help. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.

--- a/docs/commands/New-PesterOption.mdx
+++ b/docs/commands/New-PesterOption.mdx
@@ -147,6 +147,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [https://pester.dev/docs/commands/Invoke-Pester](https://pester.dev/docs/commands/Invoke-Pester)
 
-## ADDITIONAL INFORMATION
+## EDIT THIS PAGE
 
-This page was auto-generated using the [Pester](https://github.com/pester/pester) Get-Help documentation for this specific function.
+This page was auto-generated using Pester's comment based help. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.

--- a/docs/commands/New-PesterOption.mdx
+++ b/docs/commands/New-PesterOption.mdx
@@ -9,6 +9,7 @@ keywords:
   - Documentation
 hide_title: false
 hide_table_of_contents: false
+custom_edit_url: null
 ---
 
 ## SYNOPSIS

--- a/docs/commands/New-PesterOption.mdx
+++ b/docs/commands/New-PesterOption.mdx
@@ -146,3 +146,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## RELATED LINKS
 
 [https://pester.dev/docs/commands/Invoke-Pester](https://pester.dev/docs/commands/Invoke-Pester)
+
+## ADDITIONAL INFORMATION
+
+This page was auto-generated using the [Pester](https://github.com/pester/pester) Get-Help documentation for this specific function.

--- a/docs/commands/Set-ItResult.mdx
+++ b/docs/commands/Set-ItResult.mdx
@@ -9,6 +9,7 @@ keywords:
   - Documentation
 hide_title: false
 hide_table_of_contents: false
+custom_edit_url: null
 ---
 
 ## SYNOPSIS

--- a/docs/commands/Set-ItResult.mdx
+++ b/docs/commands/Set-ItResult.mdx
@@ -164,6 +164,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-## ADDITIONAL INFORMATION
+## EDIT THIS PAGE
 
-This page was auto-generated using the [Pester](https://github.com/pester/pester) Get-Help documentation for this specific function.
+This page was auto-generated using Pester's comment based help. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.

--- a/docs/commands/Set-ItResult.mdx
+++ b/docs/commands/Set-ItResult.mdx
@@ -163,3 +163,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
+
+## ADDITIONAL INFORMATION
+
+This page was auto-generated using the [Pester](https://github.com/pester/pester) Get-Help documentation for this specific function.

--- a/docs/commands/Set-TestInconclusive.mdx
+++ b/docs/commands/Set-TestInconclusive.mdx
@@ -78,3 +78,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
+
+## ADDITIONAL INFORMATION
+
+This page was auto-generated using the [Pester](https://github.com/pester/pester) Get-Help documentation for this specific function.

--- a/docs/commands/Set-TestInconclusive.mdx
+++ b/docs/commands/Set-TestInconclusive.mdx
@@ -9,6 +9,7 @@ keywords:
   - Documentation
 hide_title: false
 hide_table_of_contents: false
+custom_edit_url: null
 ---
 
 ## SYNOPSIS

--- a/docs/commands/Set-TestInconclusive.mdx
+++ b/docs/commands/Set-TestInconclusive.mdx
@@ -79,6 +79,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-## ADDITIONAL INFORMATION
+## EDIT THIS PAGE
 
-This page was auto-generated using the [Pester](https://github.com/pester/pester) Get-Help documentation for this specific function.
+This page was auto-generated using Pester's comment based help. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.

--- a/docs/commands/Setup.mdx
+++ b/docs/commands/Setup.mdx
@@ -9,6 +9,7 @@ keywords:
   - Documentation
 hide_title: false
 hide_table_of_contents: false
+custom_edit_url: null
 ---
 
 ## SYNOPSIS

--- a/docs/commands/Setup.mdx
+++ b/docs/commands/Setup.mdx
@@ -126,3 +126,7 @@ Accept wildcard characters: False
 ## NOTES
 
 ## RELATED LINKS
+
+## ADDITIONAL INFORMATION
+
+This page was auto-generated using the [Pester](https://github.com/pester/pester) Get-Help documentation for this specific function.

--- a/docs/commands/Setup.mdx
+++ b/docs/commands/Setup.mdx
@@ -127,6 +127,6 @@ Accept wildcard characters: False
 
 ## RELATED LINKS
 
-## ADDITIONAL INFORMATION
+## EDIT THIS PAGE
 
-This page was auto-generated using the [Pester](https://github.com/pester/pester) Get-Help documentation for this specific function.
+This page was auto-generated using Pester's comment based help. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.

--- a/docs/commands/Should.mdx
+++ b/docs/commands/Should.mdx
@@ -9,6 +9,7 @@ keywords:
   - Documentation
 hide_title: false
 hide_table_of_contents: false
+custom_edit_url: null
 ---
 
 ## SYNOPSIS

--- a/docs/commands/Should.mdx
+++ b/docs/commands/Should.mdx
@@ -888,3 +888,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
+
+## ADDITIONAL INFORMATION
+
+This page was auto-generated using the [Pester](https://github.com/pester/pester) Get-Help documentation for this specific function.

--- a/docs/commands/Should.mdx
+++ b/docs/commands/Should.mdx
@@ -889,6 +889,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-## ADDITIONAL INFORMATION
+## EDIT THIS PAGE
 
-This page was auto-generated using the [Pester](https://github.com/pester/pester) Get-Help documentation for this specific function.
+This page was auto-generated using Pester's comment based help. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -96,6 +96,7 @@ module.exports = {
       {
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
+          editUrl: 'https://github.com/pester/docs/edit/master',
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),


### PR DESCRIPTION
This PR:

1. enables the `Edit this Page` buttons for all pages (links go straight into Github editor mode)
2. append an `EDIT THIS PAGE` markdown section to all get-help pages

**Good to know:** 

- `Edit this Page` buttons are NOT enabled for the auto-generated command reference pages
- disabled by setting docusaurus frontmatter `custom_edit_url: 'null'` for those get-help pages