### PR TITLE
Fix pluralized Assert-VerifiableMocks

### DIFF
--- a/docs/usage/modules.mdx
+++ b/docs/usage/modules.mdx
@@ -49,7 +49,7 @@ Describe "BuildIfChanged" {
         $result = BuildIfChanged
 
         It "Builds the next version and calls Write-Host" {
-            Assert-VerifiableMocks
+            Assert-VerifiableMock
         }
 
         It "returns the next version number" {


### PR DESCRIPTION
This changes `Assert-VerifiableMocks` which no longer exists in v5 to `Assert-VerifiableMock`.