### PR TITLE
Updated usage\modules

### DIFF
--- a/docs/usage/modules.mdx
+++ b/docs/usage/modules.mdx
@@ -19,7 +19,7 @@ function Build ($version) {
 }
 
 # Actual definitions of Get-Version and Get-NextVersion are not shown here,
-# since we'll just be mocking them anyway.  However, the commands do need to
+# since we'll just be mocking them anyway. However, the commands do need to
 # exist in order to be mocked, so we'll stick dummy functions here
 
 function Get-Version { return 0 }
@@ -28,28 +28,33 @@ function Get-NextVersion { return 0 }
 Export-ModuleMember -Function BuildIfChanged
 ```
 
-You wish to write a unit test for this module which mocks the calls to `Get-Version` and `Get-NextVersion` from the module's `BuildIfChanged` command.  In older versions of Pester, this was not possible.  As of version 3.0, there are two ways you can perform unit tests of PowerShell script modules.  The first is to inject mocks into a module:
+You wish to write a unit test for this module which mocks the calls to `Get-Version` and `Get-NextVersion` from the module's `BuildIfChanged` command. In older versions of Pester, this was not possible. As of version 3.0, there are two ways you can perform unit tests of PowerShell script modules. The first is to inject mocks into a module:
 
 For these example, we'll assume that the PSM1 file is named "MyModule.psm1", and that it is installed on your PSModulePath.
 
 ```powershell
-Import-Module MyModule
+BeforeAll {
+    Import-Module MyModule
+}
 
 Describe "BuildIfChanged" {
     Context "When there are Changes" {
-        Mock -ModuleName MyModule Get-Version { return 1.1 }
-        Mock -ModuleName MyModule Get-NextVersion { return 1.2 }
 
-        # Just for giggles, we'll also mock Write-Host here, to demonstrate that you can
-        # mock calls to commands other than functions defined within the same module.
-        Mock -ModuleName MyModule Write-Host {} -Verifiable -ParameterFilter {
-            $Object -eq 'a build was run for version: 1.2'
+        BeforeAll {
+            Mock -ModuleName MyModule Get-Version { return 1.1 }
+            Mock -ModuleName MyModule Get-NextVersion { return 1.2 }
+
+            # Just for giggles, we'll also mock Write-Host here, to demonstrate that you can
+            # mock calls to commands other than functions defined within the same module.
+            Mock -ModuleName MyModule Write-Host {} -Verifiable -ParameterFilter {
+                $Object -eq 'a build was run for version: 1.2'
+            }
+
+            $result = BuildIfChanged
         }
 
-        $result = BuildIfChanged
-
         It "Builds the next version and calls Write-Host" {
-            Assert-VerifiableMock
+            Should -InvokeVerifiable
         }
 
         It "returns the next version number" {
@@ -58,14 +63,19 @@ Describe "BuildIfChanged" {
     }
 
     Context "When there are no Changes" {
-        Mock -ModuleName MyModule Get-Version { return 1.1 }
-        Mock -ModuleName MyModule Get-NextVersion { return 1.1 }
-        Mock -ModuleName MyModule Build { }
 
-        $result = BuildIfChanged
+        BeforeAll {
+            Mock -ModuleName MyModule Get-Version { return 1.1 }
+            Mock -ModuleName MyModule Get-NextVersion { return 1.1 }
+            Mock -ModuleName MyModule Build { }
+
+            $result = BuildIfChanged
+        }
 
         It "Should not build the next version" {
-            Assert-MockCalled Build -ModuleName MyModule -Times 0 -ParameterFilter {
+            # -Scope Context is used below since BuildIfChanged is called in BeforeAll
+            # It's not required when the mock is called inside It
+            Should -Invoke Build -ModuleName MyModule -Times 0 -Scope Context -ParameterFilter {
                 $version -eq 1.1
             }
         }
@@ -73,22 +83,25 @@ Describe "BuildIfChanged" {
 }
 ```
 
-Notice that in this example test script, all calls to [Mock](../commands/Mock) and [Assert‐MockCalled](../commands/Assert-MockCalled) have had the `-ModuleName MyModule` parameter added.  This tells Pester to inject the mock into the module's scope, which causes any calls to those commands from inside the module to execute the mock instead.
+Notice that in this example test script, all calls to [Mock](../commands/Mock) and [Should -Invoke](../commands/Should) have had the `-ModuleName MyModule` parameter added. This tells Pester to inject the mock into the module's scope, which causes any calls to those commands from inside the module to execute the mock instead.
 
-When you write your test script this way, you can mock commands that are called by the module's internal functions.  However, your test script is still limited to accessing the public, exported members of the module.  If you wanted to write a unit test that calls Build directly, for example, it wouldn't work using the above technique.  That's where the second approach to script module testing comes into play.  With Pester 3.0's `InModuleScope` command, you can cause entire sections of your test script to execute inside the targeted script module.  This gives you access to non-exported members of the module.  For example:
+When you write your test script this way, you can mock commands that are called by the module's internal functions. However, your test script is still limited to accessing the public, exported members of the module. If you wanted to write a unit test that calls Build directly, for example, it wouldn't work using the above technique. That's where the second approach to script module testing comes into play. With Pester's `InModuleScope` command, you can cause entire sections of your test script to execute inside the targeted script module. This gives you access to non-exported members of the module. For example:
 
 ```posh
-Import-Module MyModule
+BeforeAll {
+    Import-Module MyModule
+}
 
 Describe "Unit testing the module's internal Build function:" {
-    InModuleScope MyModule {
-        $testVersion = 5.0
-        Mock Write-Host { }
 
-        Build $testVersion
+    It 'Outputs the correct message' {
+        InModuleScope MyModule {
+            $testVersion = 5.0
+            Mock Write-Host { }
 
-        It 'Outputs the correct message' {
-            Assert-MockCalled Write-Host -ParameterFilter {
+            Build $testVersion
+
+            Should -Invoke Write-Host -ParameterFilter {
                 $Object -eq "a build was run for version: $testVersion"
             }
         }
@@ -96,4 +109,11 @@ Describe "Unit testing the module's internal Build function:" {
 }
 ```
 
-Notice that when using `InModuleScope`, you no longer need to specify a `-ModuleName` parameter when calling `Mock` or `Assert-MockCalled` for commands within that module.  You are also able to directly call the `Build` function, which the module does not export.
+Notice that when using `InModuleScope`, you no longer need to specify a `-ModuleName` parameter when calling `Mock` or `Should -Invoke` for commands within that module. You are also able to directly call the `Build` function, which the module does not export.
+
+---
+:warning: **Avoid putting in InModuleScope around your Describe and It blocks.**
+
+`InModuleScope` is a simple way to expose your internal module functions to be tested, but it prevents you from properly testing your published functions, does not ensure that your functions are actually published and slows down test discovery by loading the module. Aim to avoid it altogether by using `-ModuleName` on `Mock` when possible or at least limit it to inside the It block like the sample above.
+
+---


### PR DESCRIPTION
Updating Usages\Modules page with Pester 5 compliant code, updates links and warning about using InModuleScope too much (based on README in Pester repo)

Fix pester/Pester#1693