### PR TITLE
Add devcontainer support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,3 +1,8 @@
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/master/containers/javascript-node/.devcontainer/base.Dockerfile
 ARG VARIANT="10"
 FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:${VARIANT}

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,7 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/master/containers/javascript-node/.devcontainer/base.Dockerfile
+ARG VARIANT="10"
+FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:${VARIANT}
+
+# Install PowerShell 7
+RUN wget https://packages.microsoft.com/config/debian/10/packages-microsoft-prod.deb && sudo dpkg -i packages-microsoft-prod.deb \
+    && apt-get update && apt-get install -y powershell

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,31 @@
+// For format details, see https://aka.ms/vscode-remote/devcontainer.json
+{
+	"name": "Node.js w/Powershell",
+	"build": {
+		"dockerfile": "Dockerfile",
+		// Update 'VARIANT' to pick a Node version: 10, 12, 14
+		"args": { "VARIANT": "10" }
+	},
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"dbaeumer.vscode-eslint",
+		"silvenon.mdx",
+		"ms-vscode.powershell"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [3000],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// Restoring node-modules
+	"postCreateCommand": "yarn"
+
+	// Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
+	// "remoteUser": "node"
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,16 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"label": "Start Docusaurus with polling",
+			"command": "yarn",
+			"type": "process",
+			// Polling for devcontainer support
+			"args": [
+				"start",
+				"--poll"
+			],
+			"problemMatcher": []
+		}
+	]
+}


### PR DESCRIPTION
This PR adds an initial devcontainer-configuration to the repo. A devcontainer provides an isolated docker container to develop, build and test the project which help contributors get up and running quickly with the required build tools.

Using VSCode + "Remote - Container" extension or Github Codespace, this is all seamless to the user and even the projects recommended extensions are installed.

PR also includes a pre-configured vscode task to start the docusaurus project with "polling mode" to support live-reloading (filesystem watcher mode didn't work in devcontainer)