### PR TITLE
Set version of Pester via parameter

### DIFF
--- a/generate-command-reference.ps1
+++ b/generate-command-reference.ps1
@@ -1,11 +1,16 @@
 #Requires -Modules @{ ModuleName="Alt3.Docusaurus.Powershell"; ModuleVersion="1.0.13" }
-#requires -Module PlatyPS
-#Requires -Modules @{ ModuleName="Pester"; ModuleVersion="5.0.3" }
+#Requires -Module PlatyPS
 
 <#
     .SYNOPSIS
       Example script to show how to (CI/CD) re-generate the Command Reference
 #>
+param (
+  [string] $PesterVersion = "5.1.0"
+)
+
+Import-Module -Name Pester -RequiredVersion $PesterVersion -Force | Out-Null
+
 $PSDefaultParameterValues['*:ErrorAction'] = "Stop" # full script stop on first error
 
 Push-Location $PSScriptRoot


### PR DESCRIPTION
The mimimum amount of work to set the Pester version externally. I think you already install it so I did not do that here. And I also assume that you don't have multiple other versions of Pester imported. 