### PR TITLE
Bump command reference to Pester 5.1.1

### DIFF
--- a/docs/commands/Add-ShouldOperator.mdx
+++ b/docs/commands/Add-ShouldOperator.mdx
@@ -161,6 +161,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
+[https://pester.dev/docs/commands/Add-ShouldOperator](https://pester.dev/docs/commands/Add-ShouldOperator)
+
 ## EDIT THIS PAGE
 
-This page was auto-generated using the comment based help in Pester 5.1.0. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.
+This page was auto-generated using the comment based help in Pester 5.1.1. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.

--- a/docs/commands/AfterAll.mdx
+++ b/docs/commands/AfterAll.mdx
@@ -101,6 +101,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [https://pester.dev/docs/usage/setup-and-teardown](https://pester.dev/docs/usage/setup-and-teardown)
 
+[about_BeforeEach_AfterEach]()
+
 ## EDIT THIS PAGE
 
-This page was auto-generated using the comment based help in Pester 5.1.0. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.
+This page was auto-generated using the comment based help in Pester 5.1.1. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.

--- a/docs/commands/AfterAll.mdx
+++ b/docs/commands/AfterAll.mdx
@@ -101,8 +101,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [https://pester.dev/docs/usage/setup-and-teardown](https://pester.dev/docs/usage/setup-and-teardown)
 
-[about_BeforeEach_AfterEach]()
-
 ## EDIT THIS PAGE
 
 This page was auto-generated using the comment based help in Pester 5.1.1. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.

--- a/docs/commands/AfterEach.mdx
+++ b/docs/commands/AfterEach.mdx
@@ -100,6 +100,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [https://pester.dev/docs/usage/setup-and-teardown](https://pester.dev/docs/usage/setup-and-teardown)
 
+[about_BeforeEach_AfterEach]()
+
 ## EDIT THIS PAGE
 
-This page was auto-generated using the comment based help in Pester 5.1.0. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.
+This page was auto-generated using the comment based help in Pester 5.1.1. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.

--- a/docs/commands/AfterEach.mdx
+++ b/docs/commands/AfterEach.mdx
@@ -100,8 +100,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [https://pester.dev/docs/usage/setup-and-teardown](https://pester.dev/docs/usage/setup-and-teardown)
 
-[about_BeforeEach_AfterEach]()
-
 ## EDIT THIS PAGE
 
 This page was auto-generated using the comment based help in Pester 5.1.1. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.

--- a/docs/commands/Assert-MockCalled.mdx
+++ b/docs/commands/Assert-MockCalled.mdx
@@ -176,6 +176,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
+[https://pester.dev/docs/commands/Assert-MockCalled](https://pester.dev/docs/commands/Assert-MockCalled)
+
 ## EDIT THIS PAGE
 
-This page was auto-generated using the comment based help in Pester 5.1.0. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.
+This page was auto-generated using the comment based help in Pester 5.1.1. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.

--- a/docs/commands/Assert-VerifiableMock.mdx
+++ b/docs/commands/Assert-VerifiableMock.mdx
@@ -53,6 +53,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
+[https://pester.dev/docs/commands/Assert-VerifiableMock](https://pester.dev/docs/commands/Assert-VerifiableMock)
+
 ## EDIT THIS PAGE
 
-This page was auto-generated using the comment based help in Pester 5.1.0. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.
+This page was auto-generated using the comment based help in Pester 5.1.1. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.

--- a/docs/commands/BeforeAll.mdx
+++ b/docs/commands/BeforeAll.mdx
@@ -113,8 +113,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [https://pester.dev/docs/usage/setup-and-teardown](https://pester.dev/docs/usage/setup-and-teardown)
 
-[about_BeforeEach_AfterEach]()
-
 ## EDIT THIS PAGE
 
 This page was auto-generated using the comment based help in Pester 5.1.1. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.

--- a/docs/commands/BeforeAll.mdx
+++ b/docs/commands/BeforeAll.mdx
@@ -113,6 +113,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [https://pester.dev/docs/usage/setup-and-teardown](https://pester.dev/docs/usage/setup-and-teardown)
 
+[about_BeforeEach_AfterEach]()
+
 ## EDIT THIS PAGE
 
-This page was auto-generated using the comment based help in Pester 5.1.0. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.
+This page was auto-generated using the comment based help in Pester 5.1.1. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.

--- a/docs/commands/BeforeDiscovery.mdx
+++ b/docs/commands/BeforeDiscovery.mdx
@@ -34,23 +34,27 @@ putting code directly inside of Describe / Context.
 ### EXAMPLE 1
 
 ```powershell
-PS \> BeforeDiscovery {
-    $files = "file1.txt", "file2.txt"
+BeforeDiscovery {
+    $files = Get-ChildItem -Path $PSScriptRoot -Filter '*.ps1' -Recurse
 }
 
-Describe "File tests" {
-    foreach ($file in $files) {
-        It "test" {
+Describe "File - \<_\>" -ForEach $files {
+    Context "Whitespace" {
+        It "There is no extra whitespace following a line" {
             # ...
 
-test code
+        }
+
+        It "File ends with an empty line" {
+            # ...
+
         }
     }
 }
 ```
 
-The result of commands will be execution of tests and saving results of them in a NUnitMXL file where the root "test-suite"
-will be named "Tests - Set A".
+BeforeDiscovery is used to gather a list of script-files during Discovery-phase to
+dynamically create a Describe-block and tests for each file found.
 
 ## PARAMETERS
 
@@ -82,6 +86,10 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
+[https://pester.dev/docs/commands/BeforeDiscovery](https://pester.dev/docs/commands/BeforeDiscovery)
+
+[https://pester.dev/docs/usage/data-driven-tests](https://pester.dev/docs/usage/data-driven-tests)
+
 ## EDIT THIS PAGE
 
-This page was auto-generated using the comment based help in Pester 5.1.0. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.
+This page was auto-generated using the comment based help in Pester 5.1.1. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.

--- a/docs/commands/BeforeEach.mdx
+++ b/docs/commands/BeforeEach.mdx
@@ -98,6 +98,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [https://pester.dev/docs/usage/setup-and-teardown](https://pester.dev/docs/usage/setup-and-teardown)
 
+[about_BeforeEach_AfterEach]()
+
 ## EDIT THIS PAGE
 
-This page was auto-generated using the comment based help in Pester 5.1.0. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.
+This page was auto-generated using the comment based help in Pester 5.1.1. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.

--- a/docs/commands/BeforeEach.mdx
+++ b/docs/commands/BeforeEach.mdx
@@ -98,8 +98,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [https://pester.dev/docs/usage/setup-and-teardown](https://pester.dev/docs/usage/setup-and-teardown)
 
-[about_BeforeEach_AfterEach]()
-
 ## EDIT THIS PAGE
 
 This page was auto-generated using the comment based help in Pester 5.1.1. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.

--- a/docs/commands/Context.mdx
+++ b/docs/commands/Context.mdx
@@ -43,19 +43,22 @@ function Add-Numbers($a, $b) {
 }
 
 Describe "Add-Numbers" {
-
     Context "when root does not exist" {
-         It "..." { ...
-}
+        It "..." {
+            # ...
+
+        }
     }
 
     Context "when root does exist" {
-        It "..." { ...
-}
-        It "..." { ...
-}
-        It "..." { ...
-}
+        It "..." {
+            # ...
+
+        }
+        It "..." {
+            # ...
+
+        }
     }
 }
 ```
@@ -164,15 +167,9 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[https://pester.dev/docs/commands/Describe](https://pester.dev/docs/commands/Describe)
+[https://pester.dev/docs/commands/Context](https://pester.dev/docs/commands/Context)
 
-[https://pester.dev/docs/commands/It](https://pester.dev/docs/commands/It)
-
-[https://pester.dev/docs/commands/BeforeEach](https://pester.dev/docs/commands/BeforeEach)
-
-[https://pester.dev/docs/commands/AfterEach](https://pester.dev/docs/commands/AfterEach)
-
-[https://pester.dev/docs/commands/Should](https://pester.dev/docs/commands/Should)
+[https://pester.dev/docs/usage/test-file-structure](https://pester.dev/docs/usage/test-file-structure)
 
 [https://pester.dev/docs/usage/mocking](https://pester.dev/docs/usage/mocking)
 
@@ -180,4 +177,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## EDIT THIS PAGE
 
-This page was auto-generated using the comment based help in Pester 5.1.0. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.
+This page was auto-generated using the comment based help in Pester 5.1.1. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.

--- a/docs/commands/ConvertTo-JUnitReport.mdx
+++ b/docs/commands/ConvertTo-JUnitReport.mdx
@@ -42,9 +42,8 @@ as part of a CI/CD pipeline.
 
 ```powershell
 $p = Invoke-Pester -Passthru
-```
-
 $p | ConvertTo-JUnitReport
+```
 
 This example runs Pester using the Passthru option to retrieve the result-object and
 converts it to an JUnit 4-compatible XML-report.
@@ -54,9 +53,8 @@ The report is returned as an XML-object.
 
 ```powershell
 $p = Invoke-Pester -Passthru
-```
-
 $p | ConvertTo-JUnitReport -AsString
+```
 
 This example runs Pester using the Passthru option to retrieve the result-object and
 converts it to an JUnit 4-compatible XML-report.
@@ -116,4 +114,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## EDIT THIS PAGE
 
-This page was auto-generated using the comment based help in Pester 5.1.0. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.
+This page was auto-generated using the comment based help in Pester 5.1.1. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.

--- a/docs/commands/ConvertTo-NUnitReport.mdx
+++ b/docs/commands/ConvertTo-NUnitReport.mdx
@@ -42,9 +42,8 @@ as part of a CI/CD pipeline.
 
 ```powershell
 $p = Invoke-Pester -Passthru
-```
-
 $p | ConvertTo-NUnitReport
+```
 
 This example runs Pester using the Passthru option to retrieve the result-object and
 converts it to an NUnit 2.5-compatible XML-report.
@@ -54,9 +53,8 @@ The report is returned as an XML-object.
 
 ```powershell
 $p = Invoke-Pester -Passthru
-```
-
 $p | ConvertTo-NUnitReport -AsString
+```
 
 This example runs Pester using the Passthru option to retrieve the result-object and
 converts it to an NUnit 2.5-compatible XML-report.
@@ -116,4 +114,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## EDIT THIS PAGE
 
-This page was auto-generated using the comment based help in Pester 5.1.0. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.
+This page was auto-generated using the comment based help in Pester 5.1.1. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.

--- a/docs/commands/ConvertTo-Pester4Result.mdx
+++ b/docs/commands/ConvertTo-Pester4Result.mdx
@@ -38,9 +38,8 @@ having to redesign compelx CI/CD-pipelines.
 
 ```powershell
 $pester5Result = Invoke-Pester -Passthru
-```
-
 $pester4Result = $pester5Result | ConvertTo-Pester4Result
+```
 
 This example runs Pester using the Passthru option to retrieve a result-object
 in the Pester 5 format and converts it to a new Pester 4-compatible result-object.
@@ -83,4 +82,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## EDIT THIS PAGE
 
-This page was auto-generated using the comment based help in Pester 5.1.0. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.
+This page was auto-generated using the comment based help in Pester 5.1.1. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.

--- a/docs/commands/Describe.mdx
+++ b/docs/commands/Describe.mdx
@@ -28,7 +28,7 @@ Describe [-Name] <String> [-Tag <String[]>] [[-Fixture] <ScriptBlock>] [-Skip] [
 Creates a logical group of tests.
 All Mocks, TestDrive and TestRegistry contents
 defined within a Describe block are scoped to that Describe; they
-will no longer be present when the Describe block exits. 
+will no longer be present when the Describe block exits.
 A Describe
 block may contain any number of Context and It blocks.
 
@@ -179,12 +179,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [https://pester.dev/docs/usage/test-file-structure](https://pester.dev/docs/usage/test-file-structure)
 
 [https://pester.dev/docs/usage/mocking](https://pester.dev/docs/usage/mocking)
-
-[about_Should]()
-
-[about_Mocking]()
-
-[about_TestDrive]()
 
 [https://pester.dev/docs/usage/testdrive](https://pester.dev/docs/usage/testdrive)
 

--- a/docs/commands/Describe.mdx
+++ b/docs/commands/Describe.mdx
@@ -28,7 +28,7 @@ Describe [-Name] <String> [-Tag <String[]>] [[-Fixture] <ScriptBlock>] [-Skip] [
 Creates a logical group of tests.
 All Mocks, TestDrive and TestRegistry contents
 defined within a Describe block are scoped to that Describe; they
-will no longer be present when the Describe block exits.
+will no longer be present when the Describe block exits. 
 A Describe
 block may contain any number of Context and It blocks.
 
@@ -176,12 +176,18 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [https://pester.dev/docs/commands/Describe](https://pester.dev/docs/commands/Describe)
 
-[https://pester.dev/docs/commands/It](https://pester.dev/docs/commands/It)
+[https://pester.dev/docs/usage/test-file-structure](https://pester.dev/docs/usage/test-file-structure)
 
-[https://pester.dev/docs/commands/Context](https://pester.dev/docs/commands/Context)
+[https://pester.dev/docs/usage/mocking](https://pester.dev/docs/usage/mocking)
 
-[https://pester.dev/docs/commands/Invoke-Pester](https://pester.dev/docs/commands/Invoke-Pester)
+[about_Should]()
+
+[about_Mocking]()
+
+[about_TestDrive]()
+
+[https://pester.dev/docs/usage/testdrive](https://pester.dev/docs/usage/testdrive)
 
 ## EDIT THIS PAGE
 
-This page was auto-generated using the comment based help in Pester 5.1.0. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.
+This page was auto-generated using the comment based help in Pester 5.1.1. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.

--- a/docs/commands/Export-JUnitReport.mdx
+++ b/docs/commands/Export-JUnitReport.mdx
@@ -41,9 +41,8 @@ as part of a CI/CD pipeline.
 
 ```powershell
 $p = Invoke-Pester -Passthru
-```
-
 $p | Export-JUnitReport -Path TestResults.xml
+```
 
 This example runs Pester using the Passthru option to retrieve the result-object and
 exports it as an JUnit 4-compatible XML-report.
@@ -102,4 +101,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## EDIT THIS PAGE
 
-This page was auto-generated using the comment based help in Pester 5.1.0. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.
+This page was auto-generated using the comment based help in Pester 5.1.1. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.

--- a/docs/commands/Export-NUnitReport.mdx
+++ b/docs/commands/Export-NUnitReport.mdx
@@ -41,9 +41,8 @@ as part of a CI/CD pipeline.
 
 ```powershell
 $p = Invoke-Pester -Passthru
-```
-
 $p | Export-NUnitReport -Path TestResults.xml
+```
 
 This example runs Pester using the Passthru option to retrieve the result-object and
 exports it as an NUnit 2.5-compatible XML-report.
@@ -102,4 +101,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## EDIT THIS PAGE
 
-This page was auto-generated using the comment based help in Pester 5.1.0. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.
+This page was auto-generated using the comment based help in Pester 5.1.1. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.

--- a/docs/commands/Get-ShouldOperator.mdx
+++ b/docs/commands/Get-ShouldOperator.mdx
@@ -84,8 +84,10 @@ standard PowerShell discovery patterns (like `Get-Help Should -Parameter *`).
 
 ## RELATED LINKS
 
+[https://pester.dev/docs/commands/Get-ShouldOperator](https://pester.dev/docs/commands/Get-ShouldOperator)
+
 [https://pester.dev/docs/commands/Should](https://pester.dev/docs/commands/Should)
 
 ## EDIT THIS PAGE
 
-This page was auto-generated using the comment based help in Pester 5.1.0. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.
+This page was auto-generated using the comment based help in Pester 5.1.1. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.

--- a/docs/commands/InModuleScope.mdx
+++ b/docs/commands/InModuleScope.mdx
@@ -154,6 +154,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
+[https://pester.dev/docs/commands/InModuleScope](https://pester.dev/docs/commands/InModuleScope)
+
 ## EDIT THIS PAGE
 
-This page was auto-generated using the comment based help in Pester 5.1.0. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.
+This page was auto-generated using the comment based help in Pester 5.1.1. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.

--- a/docs/commands/Invoke-Pester.mdx
+++ b/docs/commands/Invoke-Pester.mdx
@@ -694,8 +694,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [https://pester.dev/docs/quick-start](https://pester.dev/docs/quick-start)
 
-[about_Pester]()
-
 ## EDIT THIS PAGE
 
 This page was auto-generated using the comment based help in Pester 5.1.1. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.

--- a/docs/commands/Invoke-Pester.mdx
+++ b/docs/commands/Invoke-Pester.mdx
@@ -106,14 +106,19 @@ with 'Util' and their subdirectories.
 
 ```powershell
 $config = [PesterConfiguration]@{
-Should = @{ \<- # Should configuration.
+    Should = @{ # \<- Should configuration.
 
-    ErrorAction = 'Stop' # \<- "Controls if Should throws on error."
+        ErrorAction = 'Continue' # \<- Always run all Should-assertions in a test
     }
 }
 
 Invoke-Pester -Configuration $config
 ```
+
+This example runs all *.Tests.ps1 files in the current directory and its subdirectories.
+It shows how advanced configuration can be used by casting a hashtable to override
+default settings, in this case to make Pester run all Should-assertions in a test
+even if the first fails.
 
 ### EXAMPLE 4
 
@@ -121,7 +126,13 @@ Invoke-Pester -Configuration $config
 $config = [PesterConfiguration]::Default
 ```
 
+$config.TestResults.Enabled = $true
 Invoke-Pester -Configuration $config
+
+This example runs all *.Tests.ps1 files in the current directory and its subdirectories.
+It uses advanced configuration to enable testresult-output to file.
+Access $config.TestResults
+to see other testresult options like  output path and format and their default values.
 
 ## PARAMETERS
 
@@ -679,19 +690,12 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
-[https://pester.dev/docs/quick-start](https://pester.dev/docs/quick-start)
-
 [https://pester.dev/docs/commands/Invoke-Pester](https://pester.dev/docs/commands/Invoke-Pester)
 
-[https://pswiki.net/invoke-pester-pester/](https://pswiki.net/invoke-pester-pester/)
+[https://pester.dev/docs/quick-start](https://pester.dev/docs/quick-start)
 
-[https://pester.dev/docs/commands/Describe](https://pester.dev/docs/commands/Describe)
-
-[about_Pester
-
-Currently doesn't work. $IgnoreUnsafeCommands filter used in rule as workaround
-[Diagnostics.CodeAnalysis.SuppressMessageAttribute('Pester.BuildAnalyzerRules\Measure-SafeComands', 'Remove-Variable', Justification = 'Remove-Variable can't remove "optimized variables" when using "alias" for Remove-Variable.')]]()
+[about_Pester]()
 
 ## EDIT THIS PAGE
 
-This page was auto-generated using the comment based help in Pester 5.1.0. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.
+This page was auto-generated using the comment based help in Pester 5.1.1. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.

--- a/docs/commands/It.mdx
+++ b/docs/commands/It.mdx
@@ -255,4 +255,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## EDIT THIS PAGE
 
-This page was auto-generated using the comment based help in Pester 5.1.0. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.
+This page was auto-generated using the comment based help in Pester 5.1.1. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.

--- a/docs/commands/Mock.mdx
+++ b/docs/commands/Mock.mdx
@@ -97,10 +97,9 @@ The command behavior will do nothing since the ScriptBlock is empty.
 
 ```powershell
 Mock Get-ChildItem { return @{FullName = "A_File.TXT"} } -ParameterFilter { $Path -and $Path.StartsWith($env:temp\1) }
-```
-
 Mock Get-ChildItem { return @{FullName = "B_File.TXT"} } -ParameterFilter { $Path -and $Path.StartsWith($env:temp\2) }
 Mock Get-ChildItem { return @{FullName = "C_File.TXT"} } -ParameterFilter { $Path -and $Path.StartsWith($env:temp\3) }
+```
 
 Multiple mocks of the same command may be used.
 The parameter filter determines which is invoked.
@@ -304,7 +303,7 @@ Accept wildcard characters: False
 
 Optional list of parameter names in the original command
 that should not have any validation rules applied.
-This relaxes the 
+This relaxes the
 validation requirements, and allows functions that are strict about their
 parameter validation to be mocked more easily.
 
@@ -344,4 +343,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## EDIT THIS PAGE
 
-This page was auto-generated using the comment based help in Pester 5.1.0. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.
+This page was auto-generated using the comment based help in Pester 5.1.1. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.

--- a/docs/commands/New-Fixture.mdx
+++ b/docs/commands/New-Fixture.mdx
@@ -141,4 +141,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## EDIT THIS PAGE
 
-This page was auto-generated using the comment based help in Pester 5.1.0. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.
+This page was auto-generated using the comment based help in Pester 5.1.1. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.

--- a/docs/commands/New-MockObject.mdx
+++ b/docs/commands/New-MockObject.mdx
@@ -74,4 +74,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## EDIT THIS PAGE
 
-This page was auto-generated using the comment based help in Pester 5.1.0. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.
+This page was auto-generated using the comment based help in Pester 5.1.1. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.

--- a/docs/commands/New-PesterContainer.mdx
+++ b/docs/commands/New-PesterContainer.mdx
@@ -50,9 +50,8 @@ able to re-use a lot of test-code.
 
 ```powershell
 $container = New-PesterContainer -Path 'CodingStyle.Tests.ps1' -Data @{ File = "Get-Emoji.ps1" }
-```
-
 Invoke-Pester -Container $container
+```
 
 This example runs Pester using a generated ContainerInfo-object referencing a file and
 required parameters that's provided to the test-file during execution.
@@ -61,9 +60,7 @@ required parameters that's provided to the test-file during execution.
 
 ```powershell
 $sb = {
-```
-
-Describe 'Testing New-PesterContainer' {
+    Describe 'Testing New-PesterContainer' {
         It 'Useless test' {
             "foo" | Should -Not -Be "bar"
         }
@@ -71,6 +68,7 @@ Describe 'Testing New-PesterContainer' {
 }
 $container = New-PesterContainer -ScriptBlock $sb
 Invoke-Pester -Container $container
+```
 
 This example runs Pester agianst a scriptblock.
 New-PesterContainer is used to genreated
@@ -148,4 +146,4 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## EDIT THIS PAGE
 
-This page was auto-generated using the comment based help in Pester 5.1.0. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.
+This page was auto-generated using the comment based help in Pester 5.1.1. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.

--- a/docs/commands/Set-ItResult.mdx
+++ b/docs/commands/Set-ItResult.mdx
@@ -150,6 +150,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## RELATED LINKS
 
+[https://pester.dev/docs/commands/Set-ItResult](https://pester.dev/docs/commands/Set-ItResult)
+
 ## EDIT THIS PAGE
 
-This page was auto-generated using the comment based help in Pester 5.1.0. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.
+This page was auto-generated using the comment based help in Pester 5.1.1. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.

--- a/docs/commands/Should.mdx
+++ b/docs/commands/Should.mdx
@@ -1103,10 +1103,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [https://pester.dev/docs/usage/assertions](https://pester.dev/docs/usage/assertions)
 
-[about_Should]()
-
-[about_Pester]()
-
 ## EDIT THIS PAGE
 
 This page was auto-generated using the comment based help in Pester 5.1.1. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.

--- a/docs/commands/Should.mdx
+++ b/docs/commands/Should.mdx
@@ -1103,6 +1103,10 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 [https://pester.dev/docs/usage/assertions](https://pester.dev/docs/usage/assertions)
 
+[about_Should]()
+
+[about_Pester]()
+
 ## EDIT THIS PAGE
 
-This page was auto-generated using the comment based help in Pester 5.1.0. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.
+This page was auto-generated using the comment based help in Pester 5.1.1. To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information.


### PR DESCRIPTION
- fixes `generate-command-reference.ps1` not installing a module if no previous version of that module version was installed
- bumps the docs to Pester 5.1.1

**Still requires manually deleting the about_help links until https://github.com/pester/Pester/pull/1805 gets merged.**

Refs https://github.com/pester/Pester/releases/tag/5.1.1