### PR TITLE
(GH-84) Add GitHub Action to generate pull requests 

### DIFF
--- a/.github/workflows/update-from-pester.yml
+++ b/.github/workflows/update-from-pester.yml
@@ -1,0 +1,33 @@
+name: update-from-pester
+
+on:
+  workflow_dispatch:
+    inputs:
+      pester-version:
+        description: 'The version of the Pester to use for the update'
+        required: false
+        default: ''
+
+jobs:
+  update:
+    name: Update documentation from Pester
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Run generate-command-reference
+        id: generate
+        shell: pwsh
+        run: |
+          ./generate-command-reference.ps1 -PesterVersion '${{ github.event.inputs.pester-version }}' -Verbose
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3.6.0
+        with:
+          commit-message: Automatic update for Pester ${{ steps.generate.outputs.pester-version }}
+          author: GitHub Actions <actions@github.com>
+          branch-suffix: short-commit-hash
+          base: master
+          title: Automatic update for Pester ${{ steps.generate.outputs.pester-version }}
+          body: Automatic update for Pester ${{ steps.generate.outputs.pester-version }} created by the update-from-pester workflow

--- a/generate-command-reference.ps1
+++ b/generate-command-reference.ps1
@@ -1,18 +1,18 @@
 <#
-    .SYNOPSIS
-      Generates the MDX files used for the website's "Command Reference" pages.
+  .SYNOPSIS
+    Generates the MDX files used for the website's "Command Reference" pages.
 
-    .NOTES
-      Uses the latest Pester version unless a specific -PesterVersion is given.
+  .NOTES
+    Uses the latest Pester version unless a specific -PesterVersion is given.
 
-    .EXAMPLE
-      .\generate-command-reference.ps1
+  .EXAMPLE
+    .\generate-command-reference.ps1
 
-    .EXAMPLE
-      .\generate-command-reference.ps1 -PesterVersion 4.10.1
+  .EXAMPLE
+    .\generate-command-reference.ps1 -PesterVersion 4.10.1
 
-    .LINK
-      https://docusaurus-powershell.netlify.app/docs/faq/ci-cd
+  .LINK
+    https://docusaurus-powershell.netlify.app/docs/faq/ci-cd
 #>
 param (
   [Parameter(Mandatory = $False)][string] $PesterVersion

--- a/generate-command-reference.ps1
+++ b/generate-command-reference.ps1
@@ -14,8 +14,13 @@
   .LINK
     https://docusaurus-powershell.netlify.app/docs/faq/ci-cd
 #>
+[CmdletBinding()]
 param (
-  [Parameter(Mandatory = $False)][string] $PesterVersion
+  [Parameter(Mandatory = $False)][string] $PesterVersion,
+
+  [Parameter(Mandatory = $False)][string] $PlatyPSVersion,
+
+  [Parameter(Mandatory = $False)][string] $DocusaurusVersion
 )
 Set-StrictMode -Version Latest
 $PSDefaultParameterValues['*:ErrorAction'] = "Stop"
@@ -23,49 +28,40 @@ $PSDefaultParameterValues['*:ErrorAction'] = "Stop"
 Write-Host "Generating MDX files for website Command Reference" -BackgroundColor DarkGreen
 
 # -----------------------------------------------------------------------------
-# Fetch module versions from PSGallery
-# -----------------------------------------------------------------------------
-$modules = @{ }
-
-Write-Host "Fetching module versions from PSGallery..."
-if ($PesterVersion) {
-  $modules.Pester = $PesterVersion
-}
-else {
-  $modules.Pester = (Find-Module -Name Pester).Version
-}
-
-$modules."Alt3.Docusaurus.Powershell" = (Find-Module -Name Alt3.Docusaurus.Powershell).Version
-$modules.PlatyPS = (Find-Module -Name PlatyPS).Version
-
-# -----------------------------------------------------------------------------
 # Install required modules
 # -----------------------------------------------------------------------------
-$modules.GetEnumerator() | ForEach-Object {
-  Write-Host "Requires $($_.Name) $($_.Value)"
+$ModuleList = [ordered]@{
+  'PlatyPS' = $PlatyPSVersion
+  'Alt3.Docusaurus.Powershell' = $DocusaurusVersion
+  'Pester' = $PesterVersion
+}
+# Can't use the original enumerator here because we may modify the dictionary mid-process
+$ModuleList.Keys.Clone() | ForEach-Object {
+  $ModuleName = $_
+  $RequestedVersion = $ModuleList.Item($ModuleName)
+  Write-Host "Requires $ModuleName $RequestedVersion"
 
-  $installed = Get-Module -ListAvailable $_.Name
-
-  if (-not $installed) {
-    Write-Host "=> no versions installed: installing $($_.Value)"
-    Install-Module $_.Name -RequiredVersion $_.Value -Force -SkipPublisherCheck -AllowClobber -Scope CurrentUser
-    Write-Host "=> importing"
-    Import-Module -Name $_.Name -RequiredVersion $_.Value -Force
-
-    return
+  if ([String]::IsNullOrEmpty($RequestedVersion)) {
+    Write-Host "=> Fetching module versions of $ModuleName from PSGallery..."
+    $RequestedVersion = (Find-Module -Name $ModuleName).Version
+    $ModuleList.Item($ModuleName) = $RequestedVersion
+    Write-Host "=> PSGallery version is $RequestedVersion"
   }
 
-  if ($installed.Version -contains $_.Value) {
+  $Installed = Get-Module -ListAvailable $ModuleName
+  if ($Installed -and ($Installed.Version -contains $RequestedVersion)) {
     Write-Host "=> required version already installed"
-    Import-Module -Name $_.Name -RequiredVersion $_.Value -Force
-
-    return
+  } else {
+    if (-not $Installed) {
+      Write-Host "=> no versions installed: installing $RequestedVersion"
+    } else {
+      Write-Host "=> no matching version installed: installing $RequestedVersion"
+    }
+    Install-Module $ModuleName -RequiredVersion $RequestedVersion -Force -SkipPublisherCheck -AllowClobber -Scope CurrentUser
   }
 
-  Write-Host "=> no matching version installed: installing $($_.Value)"
-  Install-Module $_.Name -RequiredVersion $_.Value -Force -SkipPublisherCheck -AllowClobber -Scope CurrentUser
   Write-Host "=> importing"
-  Import-Module -Name $_.Name -RequiredVersion $_.Value -Force
+  Import-Module -Name $ModuleName -RequiredVersion $RequestedVersion -Force
 }
 
 # -----------------------------------------------------------------------------
@@ -89,7 +85,7 @@ $docusaurusOptions = @{
     "Help"
     "Documentation"
   )
-  AppendMarkdown  = "## EDIT THIS PAGE`nThis page was auto-generated using the comment based help in Pester $($modules.Pester). To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information."
+  AppendMarkdown  = "## EDIT THIS PAGE`nThis page was auto-generated using the comment based help in Pester $($ModuleList.Pester). To edit the content of this page, change the corresponding help in the [pester/Pester](https://github.com/pester/pester) repository. See our [contribution guide](https://github.com/pester/docs#contributing) for more information."
 }
 
 # -----------------------------------------------------------------------------

--- a/generate-command-reference.ps1
+++ b/generate-command-reference.ps1
@@ -105,3 +105,8 @@ New-DocusaurusHelp @docusaurusOptions
 
 Write-Host "Render completed successfully" -BackgroundColor DarkGreen
 Pop-Location
+
+if ($ENV:GITHUB_ACTIONS) {
+  # Output Workflow information
+  Write-Host "::set-output name=pester-version::$($ModuleList.Item('Pester'))"
+}


### PR DESCRIPTION
Fixes #84 

Now that the generate-command-reference script has been updated, this commit
adds a GitHub Action to run the script and automatically create a Pull Request
with the latest changes.

* This is a manual trigger workflow.  It is envisaged that the Pester/Pester
  release process will call this workflow
* This workflow can also be manually triggered if the release automation fails