### PR TITLE
fix: github action create-an-issue now using main branch

### DIFF
--- a/.github/workflows/check-broken-links.yml
+++ b/.github/workflows/check-broken-links.yml
@@ -34,7 +34,7 @@ jobs:
     - uses: actions/checkout@v2
       if: failure()
 
-    - uses: JasonEtco/create-an-issue@master
+    - uses: JasonEtco/create-an-issue@main
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:


### PR DESCRIPTION
https://github.com/JasonEtco/create-an-issue has started using `main` branch instead of `master`.