### PR TITLE
Fixing dead/redirected link

### DIFF
--- a/docs/usage/mocking.mdx
+++ b/docs/usage/mocking.mdx
@@ -87,7 +87,7 @@ Describe "BuildIfChanged" {
 ```
 
 ---
-If you need to mock calls to commands which are made from inside a Script Module, additional code is required.  For details, refer to [Unit Testing within Modules](https://github.com/pester/Pester/wiki/Unit-Testing-within-Modules)
+If you need to mock calls to commands which are made from inside a Script Module, additional code is required.  For details, refer to [Unit Testing within Modules](https://pester.dev/docs/usage/modules)
 
 ---
 


### PR DESCRIPTION
The OG link takes you to a page that says it has now moved to here: https://pester.dev/docs/usage/modules