### PR TITLE
Fix devcontainer and add vscode launch config

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,6 +7,11 @@
 ARG VARIANT="10"
 FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:${VARIANT}
 
+# Refresh GPG keys to avoid error with Yarn repo
+RUN apt-key adv --refresh-keys --keyserver keyserver.ubuntu.com
+
 # Install PowerShell 7
 RUN wget https://packages.microsoft.com/config/debian/10/packages-microsoft-prod.deb && sudo dpkg -i packages-microsoft-prod.deb \
-    && apt-get update && apt-get install -y powershell
+    && apt-get update && apt-get install -y powershell \
+    # Clean up
+    && rm packages-microsoft-prod.deb && rm -rf /var/lib/apt/lists/*

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "command": "yarn start --poll",
+            "name": "Start Docusaurus (with polling)",
+            "request": "launch",
+            "type": "node-terminal"
+        }
+    ]
+}


### PR DESCRIPTION
Fixes devcontainer docker build. Base-image had outdated GPG keys for yarn repo, which caused apt-get update to fail during PowerShell-install.

Also adds a vscode launch config for Docusaurus in response to https://github.com/pester/docs/pull/65#issuecomment-803294352.