### PR TITLE
General doc updates

### DIFF
--- a/docs/introduction/installation.mdx
+++ b/docs/introduction/installation.mdx
@@ -102,14 +102,22 @@ Or to update:
 Update-Module -Name Pester
 ```
 
-## Installing from sources
+## Installing manually
 
-To install Pester you don't have to use any package manager.
-You can download the sources directly at our [release page](https://github.com/pester/Pester/releases) and copy them to your Module directory.
-Your module directory is most likely `C:\Program Files\WindowsPowerShell\Modules\Pester` or `C:\Windows\System32\WindowsPowerShell\v1.0\Modules` (on older versions of Windows), please refer to `$env:PSModulePath` and
-[this article](https://msdn.microsoft.com/en-us/library/dd878350(v=vs.85).aspx).
+To install Pester you don't have to use any package manager. Downloading and installating it manually can be useful in e.g. offline envionments.
 
-This approach can also be used to get unreleased versions of Pester, by clicking the `Clone or download` button on the [main page](https://github.com/pester/Pester), or [clicking this link](https://github.com/pester/Pester/archive/master.zip).
+1. Download the module on a machine with internet using either:
+    - **Recommended:** `Save-Module -Name Pester -Path C:\Temp`. It will save it in a versioned folder, ex *C:\Temp\Pester\5.0.4*
+    - Or download the NuGet package from PowerShell Gallery, see [Manual Package Download](https://docs.microsoft.com/en-us/powershell/scripting/gallery/how-to/working-with-packages/manual-download)
+2. Copy the Pester-folder (ex. C:\Temp\Pester) to your destination computer and place it in one of your module directories defined by [$env:PSModulePath](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_psmodulepath). On a Windows-system it will by default include:
+    - *C:\Users\User123\Documents\WindowsPowerShell\Modules*
+    - *C:\Program Files\WindowsPowerShell\Modules*
+    - *C:\WINDOWS\system32\WindowsPowerShell\v1.0\Modules*
+3. Start PowerShell and start testing.
+
+:::note
+Step 2 is optional if you don't need simple import, automatic module detection or module auto-loading. If so, you need to import the module using an absolute path like `Import-Module C:\Temp\Pester\5.0.4`.
+:::
 
 ## Alternative package sources
 

--- a/docs/migrations/breaking-changes-in-v5.mdx
+++ b/docs/migrations/breaking-changes-in-v5.mdx
@@ -1,3 +1,8 @@
+---
+id: breaking-changes-in-v5
+title: Breaking changes in v5
+---
+
 ## Actual breaking changes
 
 - (❗ new in 5.0.1)  The Parameters of `Invoke-Pester` changed significantly, but in 5.0.1, a compatibility parameter set was added. To allow all the v4 parameters to be used, e.g. like this `Invoke-Pester -Script $testFile -PassThru -Verbose -OutputFile $tr -OutputFormat NUnitXml -CodeCoverage "$tmp/*-*.ps1" -CodeCoverageOutputFile $cc -Show All`. The compatibility is not 100%, neither -Script not -CodeCoverage take hashtables, they just take a collection of paths. The `-Strict` parameter and `-PesterOption` are ignored. The `-Output` \ `-Show` parameter takes all the values, but translates only the most used options to Pester 5 compatible options, otherwise it uses `Detailed` output. It also allows all the Pester 5 output options, to allow you to use `Diagnostic` during migration. This whole Parameter set is deprecated, and prints a warning. For more options and the Advanced interface see [simple and advanced interface](#simple-and-advanced-interface) above on how to invoke Pester.

--- a/docs/migrations/breaking-changes-in-v5.mdx
+++ b/docs/migrations/breaking-changes-in-v5.mdx
@@ -5,9 +5,8 @@ title: Breaking changes in v5
 
 ## Actual breaking changes
 
-- (❗ new in 5.0.1)  The Parameters of `Invoke-Pester` changed significantly, but in 5.0.1, a compatibility parameter set was added. To allow all the v4 parameters to be used, e.g. like this `Invoke-Pester -Script $testFile -PassThru -Verbose -OutputFile $tr -OutputFormat NUnitXml -CodeCoverage "$tmp/*-*.ps1" -CodeCoverageOutputFile $cc -Show All`. The compatibility is not 100%, neither -Script not -CodeCoverage take hashtables, they just take a collection of paths. The `-Strict` parameter and `-PesterOption` are ignored. The `-Output` \ `-Show` parameter takes all the values, but translates only the most used options to Pester 5 compatible options, otherwise it uses `Detailed` output. It also allows all the Pester 5 output options, to allow you to use `Diagnostic` during migration. This whole Parameter set is deprecated, and prints a warning. For more options and the Advanced interface see [simple and advanced interface](#simple-and-advanced-interface) above on how to invoke Pester.
+- (❗ new in 5.0.1)  The Parameters of `Invoke-Pester` changed significantly, but in 5.0.1, a compatibility parameter set was added. To allow all the v4 parameters to be used, e.g. like this `Invoke-Pester -Script $testFile -PassThru -Verbose -OutputFile $tr -OutputFormat NUnitXml -CodeCoverage "$tmp/*-*.ps1" -CodeCoverageOutputFile $cc -Show All`. The compatibility is not 100%, neither -Script not -CodeCoverage take hashtables, they just take a collection of paths. The `-Strict` parameter and `-PesterOption` are ignored. The `-Output` \ `-Show` parameter takes all the values, but translates only the most used options to Pester 5 compatible options, otherwise it uses `Detailed` output. It also allows all the Pester 5 output options, to allow you to use `Diagnostic` during migration. **This whole Legacy-parameter set is deprecated** and prints a warning when used. For more options and the Advanced interface see [simple and advanced interface](#simple-and-advanced-interface) above on how to invoke Pester.
 - PowerShell 2 is no longer supported
-- Documentation is out of date for all commands
 - Legacy syntax `Should Be` (without `-`) is removed, see [Migrating from Pester v3 to v4](./v3-to-v4)
 - Mocks are scoped based on their placement, not in whole `Describe` / `Context`. The count also depends on their placement. See [mock scoping](../usage/mocking#mocks-are-scoped-based-on-their-placement)
 - `Assert-VerifiableMocks` was removed, see [Should -Invoke](../usage/mocking#should--invoke)
@@ -16,29 +15,24 @@ title: Breaking changes in v5
 - `-Output` parameter has reduced options to `None`, `Normal`, `Detailed` and `Diagnostic`, `-Show` alias is removed
 - `-PesterOption` switch is removed
 - `-TestName` switch is replaced with `-FullNameFilter` switch
-- `-Script` option was renamed to `-Path` and takes paths only, it does not take hashtables. Parametrized scripts are not implemented at the moment, which should be solved in 5.1
-- Using `$MyInvocation.MyCommand.Path` to locate your script in `BeforeAll` does not work. This does not break it for your scripts and modules. Use `$PSScriptRoot` or `$PSCommandPath`. See [importing ps files](https://jakubjares.com/2020/04/11/pester5-importing-ps-files/) article for detailed information.
+- `-Script` option was renamed to `-Path` and takes paths only, it does not take hashtables. For parametrized scripts, see [Providing external data to tests](../usage/data-driven-tests#providing-external-data-to-tests)
+- Using `$MyInvocation.MyCommand.Path` to locate your script in `BeforeAll` does not work. This does not break it for your scripts and modules. Use `$PSScriptRoot` or `$PSCommandPath`. See [Migrating from Pester v4](../usage/importing-tested-functions#migrating-from-pester-v4) or the [importing ps files](https://jakubjares.com/2020/04/11/pester5-importing-ps-files/) article for detailed information.
 - Should `-Throw` is using `-like` to match the exception message instead of .Contains. Use `*` or any of the other `-like` wildcard to match only part of the message.
-- Variables defined during Discovery, are not available in Before*, After* and It. When generating tests via foreach blocks, make sure you pass all variables into the test using -TestCases.
+- Variables defined during Discovery, are not available in Before*, After* and It. When generating tests via foreach blocks, make sure you pass all variables into the test using -TestCases / -ForEach.
 - Gherkin is removed, and will later move to it's own module, please keep using Pester version 4.
 - `TestDrive` is defined during Run only, it cannot be used in -TestCases / -ForEach.
 
 ### Deprecated features
 
--  `Assert-MockCalled` is deprecated, it is recommended to use [Should -Invoke](../usage/mocking)
--  `Assert-VerifiableMock` is deprecated, it is recommended to use [Should -InvokeVerifiable](../usage/mocking)
+- `Assert-MockCalled` is deprecated, it is recommended to use [Should -Invoke](../usage/mocking)
+- `Assert-VerifiableMock` is deprecated, it is recommended to use [Should -InvokeVerifiable](../usage/mocking)
 
-### Additional issues to be solved in 5.1
+### Additional issues to be solved future releases
 
 - `-Strict` switch is not available
 - Inconclusive and Pending states are currently no longer available, `-Pending` and `-Inconclusive` are translated to `-Skip` both on test blocks and when using `Set-ItResult`
-- Code coverage report is not available.
-- Automatic Code coverage via -CI switch is largely untested.
-- Generating tests during using foreach during discovery time works mostly, generating them from BeforeAll, to postpone expensive work till it is needed in case the test is filtered out also works, but is hacky. Get in touch if you need it and help me refine it.
+- Automatic Code coverage via -CI switch currently disabled as it's slow. Can still be enabled using configuraitonis largely untested.
+- Generating tests using foreach during discovery time works mostly, generating them from BeforeAll, to postpone expensive work till it is needed in case the test is filtered out also works, but is hacky. Get in touch if you need it and help me refine it.
 - Running on huge codebases is largely untested
-- `IncludeVSCodeMarker` was renamed to `WriteVSCodeMarker` and moved to, PesterConfiguration object in Debug section. But it is not implemented and will be removed, I will detect VSCode by env variables
-- Documentation is out of date for all commands
-- Providing parameters to test scripts is not implemented, see [parametric scripts](https://github.com/pester/Pester/issues/1485)
-- JUnit output is missing
 
-- Noticed more of them? Share please!
+**Noticed more of them? Share please!**

--- a/docs/migrations/breaking-changes-in-v5.mdx
+++ b/docs/migrations/breaking-changes-in-v5.mdx
@@ -8,10 +8,10 @@ title: Breaking changes in v5
 - (❗ new in 5.0.1)  The Parameters of `Invoke-Pester` changed significantly, but in 5.0.1, a compatibility parameter set was added. To allow all the v4 parameters to be used, e.g. like this `Invoke-Pester -Script $testFile -PassThru -Verbose -OutputFile $tr -OutputFormat NUnitXml -CodeCoverage "$tmp/*-*.ps1" -CodeCoverageOutputFile $cc -Show All`. The compatibility is not 100%, neither -Script not -CodeCoverage take hashtables, they just take a collection of paths. The `-Strict` parameter and `-PesterOption` are ignored. The `-Output` \ `-Show` parameter takes all the values, but translates only the most used options to Pester 5 compatible options, otherwise it uses `Detailed` output. It also allows all the Pester 5 output options, to allow you to use `Diagnostic` during migration. This whole Parameter set is deprecated, and prints a warning. For more options and the Advanced interface see [simple and advanced interface](#simple-and-advanced-interface) above on how to invoke Pester.
 - PowerShell 2 is no longer supported
 - Documentation is out of date for all commands
-- Legacy syntax `Should Be` (without `-`) is removed, see [Migrating from Pester v3 to v4](https://pester.dev/docs/migrations/v3-to-v4)
-- Mocks are scoped based on their placement, not in whole `Describe` / `Context`. The count also depends on their placement. See [mock scoping](https://pester.dev/docs/usage/mocking#mocks-are-scoped-based-on-their-placement)
-- `Assert-VerifiableMocks` was removed, see [Should -Invoke](https://pester.dev/docs/usage/mocking#should--invoke)
-- All code placed in the body of `Describe` outside of `It`, `BeforeAll`, `BeforeEach`, `AfterAll`, `AfterEach` will run during discovery and it's state might or might not be available to the test code, see [Discovery and Run](https://pester.dev/docs/usage/discovery-and-run)
+- Legacy syntax `Should Be` (without `-`) is removed, see [Migrating from Pester v3 to v4](./v3-to-v4)
+- Mocks are scoped based on their placement, not in whole `Describe` / `Context`. The count also depends on their placement. See [mock scoping](../usage/mocking#mocks-are-scoped-based-on-their-placement)
+- `Assert-VerifiableMocks` was removed, see [Should -Invoke](../usage/mocking#should--invoke)
+- All code placed in the body of `Describe` outside of `It`, `BeforeAll`, `BeforeEach`, `AfterAll`, `AfterEach` will run during discovery and it's state might or might not be available to the test code, see [Discovery and Run](../usage/discovery-and-run)
 
 - `-Output` parameter has reduced options to `None`, `Normal`, `Detailed` and `Diagnostic`, `-Show` alias is removed
 - `-PesterOption` switch is removed
@@ -25,8 +25,8 @@ title: Breaking changes in v5
 
 ### Deprecated features
 
--  `Assert-MockCalled` is deprecated, it is recommended to use [Should -Invoke](https://pester.dev/docs/usage/mocking)
--  `Assert-VerifiableMock` is deprecated, it is recommended to use [Should -InvokeVerifiable](https://pester.dev/docs/usage/mocking)
+-  `Assert-MockCalled` is deprecated, it is recommended to use [Should -Invoke](../usage/mocking)
+-  `Assert-VerifiableMock` is deprecated, it is recommended to use [Should -InvokeVerifiable](../usage/mocking)
 
 ### Additional issues to be solved in 5.1
 

--- a/docs/migrations/breaking-changes-in-v5.mdx
+++ b/docs/migrations/breaking-changes-in-v5.mdx
@@ -9,9 +9,9 @@ title: Breaking changes in v5
 - PowerShell 2 is no longer supported
 - Documentation is out of date for all commands
 - Legacy syntax `Should Be` (without `-`) is removed, see [Migrating from Pester v3 to v4](https://pester.dev/docs/migrations/v3-to-v4)
-- Mocks are scoped based on their placement, not in whole `Describe` / `Context`. The count also depends on their placement. See [mock scoping](#mocks-are-scoped-based-on-their-placement)
-- `Assert-VerifiableMocks` was removed, see [Should -Invoke](#should--invoke)
-- All code placed in the body of `Describe` outside of `It`, `BeforeAll`, `BeforeEach`, `AfterAll`, `AfterEach` will run during discovery and it's state might or might not be available to the test code, see [basics of discovery](#basics-of-discovery)
+- Mocks are scoped based on their placement, not in whole `Describe` / `Context`. The count also depends on their placement. See [mock scoping](https://pester.dev/docs/usage/mocking#mocks-are-scoped-based-on-their-placement)
+- `Assert-VerifiableMocks` was removed, see [Should -Invoke](https://pester.dev/docs/usage/mocking#should--invoke)
+- All code placed in the body of `Describe` outside of `It`, `BeforeAll`, `BeforeEach`, `AfterAll`, `AfterEach` will run during discovery and it's state might or might not be available to the test code, see [Discovery and Run](https://pester.dev/docs/usage/discovery-and-run)
 
 - `-Output` parameter has reduced options to `None`, `Normal`, `Detailed` and `Diagnostic`, `-Show` alias is removed
 - `-PesterOption` switch is removed
@@ -25,8 +25,8 @@ title: Breaking changes in v5
 
 ### Deprecated features
 
--  `Assert-MockCalled` is deprecated, it is recommended to use [Should -Invoke](#should--invoke)
--  `Assert-VerifiableMock` is deprecated, it is recommended to use [Should -InvokeVerifiable](#should--invoke)
+-  `Assert-MockCalled` is deprecated, it is recommended to use [Should -Invoke](https://pester.dev/docs/usage/mocking)
+-  `Assert-VerifiableMock` is deprecated, it is recommended to use [Should -InvokeVerifiable](https://pester.dev/docs/usage/mocking)
 
 ### Additional issues to be solved in 5.1
 

--- a/docs/migrations/v4-to-v5.mdx
+++ b/docs/migrations/v4-to-v5.mdx
@@ -107,16 +107,16 @@ Invoke-Pester -Configuration <PesterConfiguration>
 
 A mapping of the parameters of the simple interface to the configuration object properties on the advanced interface is:
 
-| Parameter      | Configuration Object Property                                              |
-| -----------    | -------------------------------------------------------------------------- |
-| Path           | Run.Path                                                                   |
-| ExcludePath    | Run.ExcludePath                                                            |
-| Tag            | Filter.Tag                                                                 |
-| ExcludeTag     | Filter.ExcludeTag                                                          |
-| FullNameFilter | Filter.FullName                                                            |
-| Output         | Output.Verbosity                                                           |
-| CI             | CodeCoverage.Enabled, TestResult.Enabled and Run.Exit (all set to `$true`) |
-| PassThru       | Run.PassThru                                                               |
+| Parameter      | Configuration Object Property                        |
+| -----------    | -----------------------------------------------------|
+| Path           | Run.Path                                             |
+| ExcludePath    | Run.ExcludePath                                      |
+| Tag            | Filter.Tag                                           |
+| ExcludeTag     | Filter.ExcludeTag                                    |
+| FullNameFilter | Filter.FullName                                      |
+| Output         | Output.Verbosity                                     |
+| CI             | TestResult.Enabled and Run.Exit (all set to `$true`) |
+| PassThru       | Run.PassThru                                         |
 
 
 ## Legacy interface
@@ -127,10 +127,10 @@ The following table shows a mapping of v4 Legacy parameters (those which have no
 | ------------------------------- | ------------------------------------------------------ |
 | EnableExit                      | Run.Exit                                               |
 | CodeCoverage                    | CodeCoverage.Path                                      |
-| CodeCoverageOutputFile          | CodeCoverage.CodeCoverageOutputFile                    |
-| CodeCoverageOutputFileEncoding  | CodeCoverage.CodeCoverageOutputFileEncoding            |
-| CodeCoverageOutputFileFormat    | CodeCoverage.CodeCoverageOutputFileFormat              |
-| OutputFile                      | TestResult.OutputFile                                  |
+| CodeCoverageOutputFile          | CodeCoverage.OutputPath                                |
+| CodeCoverageOutputFileEncoding  | CodeCoverage.OutputEncoding                            |
+| CodeCoverageOutputFileFormat    | CodeCoverage.OutputFormat                              |
+| OutputFile                      | TestResult.OutputPath                                  |
 | OutputFormat                    | TestResult.OutputFormat                                |
 | Show                            | Output.Verbosity (via mapping; see below)              |
 

--- a/docs/migrations/v4-to-v5.mdx
+++ b/docs/migrations/v4-to-v5.mdx
@@ -70,7 +70,7 @@ Describe "d" {
 }
 ```
 
-Consider settings the check statically into a global read-only variable (much like `$IsWindows`), or caching the response for a while. Are you in this situation? Get in touch via the channels mentioned in [Questions?](#questions).
+Consider settings the check statically into a global read-only variable (much like `$IsWindows`), or caching the response for a while. Are you in this situation? Get in touch via the channels mentioned in [Got questions?](https://github.com/pester/pester#got-questions).
 
 ### Review your usage of TestCases
 

--- a/docs/quick-start.mdx
+++ b/docs/quick-start.mdx
@@ -339,4 +339,4 @@ Tests are written into `It` blocks and grouped by `Describe` or `Context` into g
 
 `Invoke-Pester` can then be used to run the tests in a given test file, and `-Output Detailed` can be used to show every test in the output, no matter if it passed or failed. Otherwise only failed tests, or whole files (when everything passed) are shown.
 
-To learn more, for example how to run multiple test files in one run, continue to the [Usage](usage) section.
+To learn more, for example how to run multiple test files in one run, continue to the [Usage](usage/file-placement-and-naming) section.

--- a/docs/usage/configuration.mdx
+++ b/docs/usage/configuration.mdx
@@ -1,3 +1,7 @@
+---
+title: Configuration
+---
+
 ### Advanced interface
 
 Advanced interface uses `PesterConfiguration` object which contains all options that you can provide to Pester and contains descriptions for all the configuration sections and as well as default values. Here is what you see when you look at the default Debug section of the object:

--- a/docs/usage/configuration.mdx
+++ b/docs/usage/configuration.mdx
@@ -15,6 +15,10 @@ WriteDebugMessagesFrom : Write Debug messages from a given source, WriteDebugMes
 ShowNavigationMarkers  : Write paths after every block and test, for easy navigation in VSCode. (False, default: False)
 ```
 
+:::tip New in Pester 5.2.0!
+[New-PesterConfiguration](../commands/New-PesterConfiguration) is now available and the recommended way to create the PesterConfiguration-object. It has the added benefit of auto-loading the Pester-module if needed and up-to-date help of available options in the configuration object.
+:::
+
 The configuration object can be constructed either via the Default static property or by casting a hashtable to it. You can also cast a hashtable to any of its sections. Here are three different ways to the same goal:
 
 ```powershell
@@ -56,11 +60,9 @@ $configuration.Filter = @{
     }
 $configuration.Should.ErrorAction = 'Continue'
 $configuration.CodeCoverage.Enabled = $true
-
 ```
 
 This configuration object contains all the options that are currently supported and the Simple interface is internally translates to this object internally. It is the source of truth for the defaults and configuration. The Intermediate api will be figured out later, as well as all the other details.
-
 
 ## PesterPreference
 

--- a/docs/usage/discovery-and-run.mdx
+++ b/docs/usage/discovery-and-run.mdx
@@ -133,7 +133,7 @@ foreach ($file in $files) {
 }
 ```
 
-In this case the `foreach` is evaluated during `Discovery` because we simply run the whole script file. But `BeforeAll` won't run until run `Run`, so the `$files` variable is not defined during `Discovery` and the tests are not generated. This can be solved by defining the code that is used to generate tests into `BeforeDiscovery` block. See [Data driven tests](data-driven-tests).
+In this case the `foreach` is evaluated during `Discovery` because we simply run the whole script file. But `BeforeAll` won't run until run `Run`, so the `$files` variable is not defined during `Discovery` and the tests are not generated. This can be solved by defining the code that is used to generate tests into `BeforeDiscovery` block. See [Data driven tests](data-driven-tests#beforediscovery).
 
 
 ### Variables are not available in test 

--- a/docs/usage/modules.mdx
+++ b/docs/usage/modules.mdx
@@ -111,9 +111,12 @@ Describe "Unit testing the module's internal Build function:" {
 
 Notice that when using `InModuleScope`, you no longer need to specify a `-ModuleName` parameter when calling `Mock` or `Should -Invoke` for commands within that module. You are also able to directly call the `Build` function, which the module does not export.
 
----
-:warning: **Avoid putting in InModuleScope around your Describe and It blocks.**
+:::caution Avoid putting in InModuleScope around your Describe and It blocks.
 
 `InModuleScope` is a simple way to expose your internal module functions to be tested, but it prevents you from properly testing your published functions, does not ensure that your functions are actually published and slows down test discovery by loading the module. Aim to avoid it altogether by using `-ModuleName` on `Mock` when possible or at least limit it to inside the It block like the sample above.
+:::
 
----
+:::tip Variables and functions created inside InModuleScope won't persist by default
+
+The scriptblock provided to `InModuleScope` is executed in a local scope inside the module session state. If you're creating variables, functions etc. intended to be reused in later outside of this scriptblock, use the `script:` scope-modifier to make them available to all future scopes inside the module.
+:::

--- a/docs/usage/skip.mdx
+++ b/docs/usage/skip.mdx
@@ -94,7 +94,7 @@ Invoke-Pester -Configuration $configuation
 
 ```
 Starting discovery in 1 files.
-Discovering in 
+Discovering in
     param($SkipFirst)
 
     Describe 'My Describe Block' {

--- a/docs/usage/skip.mdx
+++ b/docs/usage/skip.mdx
@@ -6,7 +6,6 @@ title: Skip
 
 `-Skip` is now available on Describe and Context. This allows you to skip all the tests in that block and every child block.
 
-
 ```powershell
 Describe "describe1" {
     Context "with one skipped test" {
@@ -57,3 +56,72 @@ Tests Passed: 1, Failed: 0, Skipped: 4, Total: 5, NotRun: 0
 :::caution
 Pending is translated to skipped, Inconclusive does not exist anymore.
 :::
+
+### Conditional skip
+
+Evaluation of the skip-parameter is done as part of the Discovery-phase. This means you can also dynamically skip tests based on values available in that phase. Either as logic done in BeforeDiscovery or based on values passed into a parametrized test.
+
+```powershell
+$sb = {
+    param($SkipFirst)
+
+    Describe 'My Describe Block' {
+        BeforeDiscovery {
+            $skipSecond = 1
+        }
+
+        It 'First Test' -Skip:$SkipFirst {
+            1 | Should -Be 1
+        }
+
+        It 'Second Test' -Skip:($skipSecond -eq 1) {
+            1 | Should -Be 1
+        }
+
+        It 'Third Test' {
+            1 | Should -Be 1
+        }
+    }
+}
+
+$container = New-PesterContainer -ScriptBlock $sb -Data @{ SkipFirst = $true }
+$configuation = New-PesterConfiguration
+$configuation.Run.Container = $container
+$configuation.Output.Verbosity = 'Detailed'
+
+Invoke-Pester -Configuration $configuation
+```
+
+```
+Starting discovery in 1 files.
+Discovering in 
+    param($SkipFirst)
+
+    Describe 'My Describe Block' {
+        BeforeDiscovery {
+            $skipSecond = 1
+        }
+
+        It 'First Test' -Skip:$SkipFirst {
+            1 | Should -Be 1
+        }
+
+        It 'Second Test' -Skip:($skipSecond -eq 1) {
+            1 | Should -Be 1
+        }
+
+        It 'Third Test' {
+            1 | Should -Be 1
+        }
+    }
+.
+Found 3 tests. 37ms
+Discovery finished in 97ms.
+Running tests.
+Describing My Describe Block
+  [!] First Test 3ms (0ms|3ms)
+  [!] Second Test 2ms (0ms|2ms)
+  [+] Third Test 18ms (16ms|3ms)
+Tests completed in 206ms
+Tests Passed: 1, Failed: 0, Skipped: 2 NotRun: 0
+```

--- a/docs/usage/test-file-structure.mdx
+++ b/docs/usage/test-file-structure.mdx
@@ -180,7 +180,7 @@ Describe "File <file> is not empty" {
     # ...
 }
 ```
-See [Data driven tests](data-driven-tests).
+See [Data driven tests](data-driven-tests#providing-external-data-to-tests).
 
 
 ### Expanding data to generate `Describe` and `Context` blocks
@@ -211,4 +211,4 @@ In Pester5 the mantra is to put all code in Pester controlled blocks. No code sh
 
 There is a special block called `BeforeDiscovery` that shows intent when you need to put code directly in the script, or directly in `Describe` or `Context` block. This is useful when Data driven tests.
 
-See [Data driven tests](data-driven-tests).
+See [Data driven tests](data-driven-tests#beforediscovery).

--- a/docs/usage/vscode.mdx
+++ b/docs/usage/vscode.mdx
@@ -1,3 +1,7 @@
+---
+title: VSCode
+---
+
 ### VSCode improvements
 
 #### Use legacy code lens


### PR DESCRIPTION
- [x] Add skip-example (fix #91)
- [x] Update manual installation docs (fix #69)
- [x] Reduce duplicate links (fix #27)
- [x] Update CodeCoverage config-properties (fix #97)
- [x] Fix missing metadata for markdown-pages. Caused lowercase and hyphen titles and navbar-links.
- [x] Fix links in docs/migrations/breaking-changes-in-v5 and v4-to-v5
- [x] Add promotion for New-PesterConfiguration in Configuration (**Link currently broken**! Missing command ref update for 5.2.0)
- [x] Update breaking changes in v5