### PR TITLE
fix broken links

### DIFF
--- a/docs/additional-resources/misc.table.js
+++ b/docs/additional-resources/misc.table.js
@@ -8,7 +8,7 @@ export const integrations = [
     title: "VSCode snippets for Pester",
     author: "Adam Bertram",
     date: "2017-03-07",
-    url: "https://powershell.org/forums/topic/vscode-snippets-for-pester/",
+    url: "https://forums.powershell.org/t/vscode-snippets-for-pester/8195",
   },
 ];
 

--- a/docs/contributing/introduction.mdx
+++ b/docs/contributing/introduction.mdx
@@ -44,7 +44,7 @@ The Pester community welcomes contributions. Please refer to the guides below on
 ## Where to get support
 
 - [Gitter](https://gitter.im/pester/Pester)
-- [Powershell.org](https://powershell.org/forums/forum/pester/)
+- [Powershell.org](https://forums.powershell.org/c/pester)
 - [Slack](https://powershell.slack.com/messages/C03QKTUCS)
 
 ### Stack Overflow

--- a/docs/introduction/installation.mdx
+++ b/docs/introduction/installation.mdx
@@ -89,7 +89,7 @@ Update-Module -Name Pester
 ### PowerShell 3 and 4
 
 On PowerShell 3 and 4, there is no default package manager installed, but luckily PowerShellGet is available for installation.
-See detailed [instructions here](https://docs.microsoft.com/en-us/powershell/gallery/installing-psget#get-powershellget-module-for-powershell-versions-30-and-40).
+See detailed [instructions here](https://docs.microsoft.com/en-us/powershell/scripting/gallery/installing-psget#for-computers-running-powershell-30-or-powershell-40).
 When you have the package manager installed, please start a new _administrator_ PowerShell window and use:
 
 ```powershell

--- a/docs/usage/vscode.mdx
+++ b/docs/usage/vscode.mdx
@@ -10,7 +10,7 @@ With Pester 5 it is finally possible to run and debug just a single test in VSCo
 
 ![Shows a single test being run using the new Code Lens](images/single-test.gif)
 
-In the latest [PowerShell Preview](https://marketplace.visualstudio.com/items?itemName=ms-vscode.PowerShell-Preview) extension for VSCode you can enable Use Legacy Code Lens option which will enable `Run tests` on all `Describe`, `Context` and `It` blocks. You can run a whole block, any child block, or any test individually. You can also run tests that are marked as skipped by running them individually.
+In the latest [PowerShell](https://marketplace.visualstudio.com/items?itemName=ms-vscode.PowerShell) extension for VSCode you can enable Use Legacy Code Lens option which will enable `Run tests` on all `Describe`, `Context` and `It` blocks. You can run a whole block, any child block, or any test individually. You can also run tests that are marked as skipped by running them individually.
 
 Actually there is a bug, and the option is called Enable Legacy Code Lens, and is enabled by default and can't be disabled. 😁 Take advantage of this and go try it right now!
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -68,7 +68,7 @@ module.exports = {
             },
             {
               label: 'PowerShell.org',
-              href: 'https://powershell.org/forums/forum/pester/',
+              href: 'https://forums.powershell.org/c/pester/',
             },
             {
               label: 'Slack',

--- a/versioned_docs/version-v4/additional-resources/misc.table.js
+++ b/versioned_docs/version-v4/additional-resources/misc.table.js
@@ -8,7 +8,7 @@ export const integrations = [
     title: "VSCode snippets for Pester",
     author: "Adam Bertram",
     date: "2017-03-07",
-    url: "https://powershell.org/forums/topic/vscode-snippets-for-pester/",
+    url: "https://forums.powershell.org/t/vscode-snippets-for-pester/8195",
   },
 ];
 

--- a/versioned_docs/version-v4/contributing/introduction.mdx
+++ b/versioned_docs/version-v4/contributing/introduction.mdx
@@ -44,7 +44,7 @@ The Pester community welcomes contributions. Please refer to the guides below on
 ## Where to get support
 
 - [Gitter](https://gitter.im/pester/Pester)
-- [Powershell.org](https://powershell.org/forums/forum/pester/)
+- [Powershell.org](https://forums.powershell.org/c/pester)
 - [Slack](https://powershell.slack.com/messages/C03QKTUCS)
 
 ### Stack Overflow

--- a/versioned_docs/version-v4/introduction/installation.mdx
+++ b/versioned_docs/version-v4/introduction/installation.mdx
@@ -78,9 +78,8 @@ Update-Module -Name Pester
 ### PowerShell 3 and 4
 
 On PowerShell 3 and 4, there is no default package manager installed, but luckily PowerShellGet is available
-for installation. See detailed
-[instructions here](https://docs.microsoft.com/en-us/powershell/gallery/installing-psget#get-powershellget-module-for-powershell-versions-30-and-40)
-. When you have the package manager installed, please start a new _administrator_ PowerShell window and use:
+for installation. See detailed [instructions here](https://docs.microsoft.com/en-us/powershell/scripting/gallery/installing-psget#for-computers-running-powershell-30-or-powershell-40).
+When you have the package manager installed, please start a new _administrator_ PowerShell window and use:
 
 ```powershell
 Install-Module -Name Pester
@@ -112,7 +111,7 @@ To install Pester you don't have to use any package manager. You can download th
 [release page](https://github.com/pester/Pester/releases) and copy them to your Module directory. Your module
 directory is most likely `C:\Program Files\WindowsPowerShell\Modules\Pester` or `C:\Windows\System32\WindowsPowerShell\v1.0\Modules`
 (on older versions of Windows), please refer to `$env:PSModulePath` and
-[this article](https://msdn.microsoft.com/en-us/library/dd878350(v=vs.85).aspx)
+[this article](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_psmodulepath)
 .
 
 This approach can also be used to get unreleased versions of Pester, by clicking the `Clone or download` button on the [main page](https://github.com/pester/Pester), or [clicking this link](https://github.com/pester/Pester/archive/master.zip).


### PR DESCRIPTION
Updating some of the broken links.
Primarily powershell.org forum links that broke after they migrated to new website+forum.