### PR TITLE
Update discovery-and-run.mdx

### DIFF
--- a/docs/usage/discovery-and-run.mdx
+++ b/docs/usage/discovery-and-run.mdx
@@ -148,7 +148,7 @@ BeforeDiscovery { # <- this will run during Discovery
 
 foreach ($file in $files) { 
     Describe "$file is correct" { 
-        It "has empty line at end" -TestCased @{ File = $file } { # <- we pass $file data to the test
+        It "has empty line at end" -TestCases @{ File = $file } { # <- we pass $file data to the test
             # ...
         }
 


### PR DESCRIPTION
Typo in in the example about using TestCases to pass variables to It blocks.