### PR TITLE
Update Assert-VerifiableMocks references in v4 docs

### DIFF
--- a/versioned_docs/version-v4/usage/mocking.mdx
+++ b/versioned_docs/version-v4/usage/mocking.mdx
@@ -20,7 +20,7 @@ With the set of Mocking functions that Pester exposes, one can:
 
 Mocks the behavior of an existing command with an alternate implementation.
 
-### Assert-VerifiableMocks
+### Assert-VerifiableMock
 
 Checks if any Verifiable Mock has not been invoked. If so, this will throw an exception.
 
@@ -55,7 +55,7 @@ Describe "BuildIfChanged" {
         $result = BuildIfChanged
 
         It "Builds the next version" {
-            Assert-VerifiableMocks
+            Assert-VerifiableMock
         }
         It "returns the next version number" {
             $result | Should Be 1.2

--- a/versioned_docs/version-v4/usage/modules.mdx
+++ b/versioned_docs/version-v4/usage/modules.mdx
@@ -49,7 +49,7 @@ Describe "BuildIfChanged" {
         $result = BuildIfChanged
 
         It "Builds the next version and calls Write-Host" {
-            Assert-VerifiableMocks
+            Assert-VerifiableMock
         }
 
         It "returns the next version number" {


### PR DESCRIPTION
Replaces some references to `Assert-VerifiableMocks` with `Assert-VerifiableMock` in the v4 docs.

Fix pester/Pester#1385