### PR TITLE
Algolia search

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -20,15 +20,27 @@ module.exports = {
         src: 'img/logo_white.svg',
       },
       items: [
-        { to: 'docs/quick-start', label: 'Docs', position: 'right' },
         {
           type: 'docsVersionDropdown',
           position: 'left',
         },
-        { to: 'docs/commands/Add-ShouldOperator', label: 'Commands', position: 'right' },
         {
-          href: 'https://github.com/pester/pester',
+          label: 'Docs',
+          to: 'docs/quick-start',
+          position: 'right'
+        },
+        {
+          label: 'Commands',
+          to: 'docs/commands/Add-ShouldOperator',
+          position: 'right'
+        },
+        {
           label: 'GitHub',
+          href: 'https://github.com/pester/pester',
+          position: 'right',
+        },
+        {
+          type: 'search', // algolia search
           position: 'right',
         },
       ],
@@ -38,6 +50,15 @@ module.exports = {
       additionalLanguages: [
         'powershell'
       ]
+    },
+    // Please note that the Algolia DocSearch crawler only runs once every 24 hours.
+    // Configuration options below described at https://docusaurus.io/docs/search.
+    algolia: {
+      apiKey: '3bc69eeabd2050b499c4a1ab01c1c3e6',
+      indexName: 'pester',
+      contextualSearch: true,
+      // searchParameters: {},
+      //... other Algolia params
     },
     footer: {
       style: 'dark',

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@docusaurus/core": "^2.0.0-beta.4",
     "@docusaurus/preset-classic": "^2.0.0-beta.4",
+    "@docusaurus/theme-search-algolia": "^2.0.0-beta.4",
     "@mdx-js/react": "^1.6.21",
     "@svgr/webpack": "^5.5.0",
     "classnames": "^2.2.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2441,7 +2441,7 @@
     fs-extra "^10.0.0"
     tslib "^2.1.0"
 
-"@docusaurus/theme-search-algolia@2.0.0-beta.4":
+"@docusaurus/theme-search-algolia@2.0.0-beta.4", "@docusaurus/theme-search-algolia@^2.0.0-beta.4":
   version "2.0.0-beta.4"
   resolved "https://registry.yarnpkg.com/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.0.0-beta.4.tgz#0c2051523428c4486ef1dd7cb5271b0d871f5c8e"
   integrity sha512-W/DfGhlAe1Vl+IJiL9rCw8yswdUrX0lTyCMNRAFi749YN4vCWo2RoxylbUuWoV6lUKoIYfj3EGyotRT2OLqtZw==


### PR DESCRIPTION
Now that we have been added to [Algolia DocSearch](https://docsearch.algolia.com/), this PR enables the SearchBar for the website.

## Good to know:

- **Crawler:** search results only get updates after the Algolia crawler has indexed the site, runs once every 24 hours
- **Contextual Search:** Docusaurus supports [contextual search](https://docusaurus.io/docs/search#contextual-search) meaning users browsing the `v4` website should only see `v4` matches in the SearchBar

> **PLEASE NOTE:** if I understand correctly, contextual search requires a new crawl after this PR is merged (because meta tags will be added to the website). Therefore, after merging **the search box will not produce results until the next crawl**.  

# SearchBar position

I propose positioning the SearchBar at this location:

![right](https://user-images.githubusercontent.com/230500/130199692-b20d7b0d-7404-48ec-a776-8fcd3cf91b46.png)

Alternative locations could be.

## Left-most

![left](https://user-images.githubusercontent.com/230500/130199756-d586a741-fe65-4845-935c-db29a0ead792.png)

## Right-most

![default](https://user-images.githubusercontent.com/230500/130201465-164284f3-29cc-4aa6-a368-ac5252d80c33.png)

## After internal pages

![after-internal](https://user-images.githubusercontent.com/230500/130199816-55c4b552-bdb3-4009-a242-3c6cb65d3f9a.png)

