### PR TITLE
Fix broken example

### DIFF
--- a/docs/usage/test-file-structure.mdx
+++ b/docs/usage/test-file-structure.mdx
@@ -188,7 +188,7 @@ See [Data driven tests](data-driven-tests#providing-external-data-to-tests).
 Much like on `It`, You can use `-ForEach` on `Describe` and `Context` to repeat it for every item in the provided array: 
 
 ```powershell
-BeforeAll { 
+BeforeDiscovery { 
     $files = @(
         "Get-Emoji.ps1",
         "Get-Planet.ps1" 


### PR DESCRIPTION
Fixes broken example in "Expanding data to generate `Describe` and `Context` blocks". `BeforeDiscovery` is required when defining variables used in `-Foreach ..`

Fix pester/pester#2125