### PR TITLE
change wording in foreach gotcha section

### DIFF
--- a/docs/usage/discovery-and-run.mdx
+++ b/docs/usage/discovery-and-run.mdx
@@ -133,7 +133,7 @@ foreach ($file in $files) {
 }
 ```
 
-In this case the `foreach` is evaluated during `Discovery` because we simply run the whole script file. But `BeforeAll` won't run until run `Run`, so the `$files` variable is not defined during `Discovery` and the tests are not generated. This can be solved by defining the code that is used to generate tests into `BeforeDiscovery` block. See [Data driven tests](data-driven-tests#beforediscovery).
+In this case the `foreach` is evaluated during `Discovery` because we simply run the whole script file. But `BeforeAll` won't be invoked until `Run`, so the `$files` variable is not defined during `Discovery` and the tests are not generated. This can be solved by defining the code that is used to generate tests into `BeforeDiscovery` block. See [Data driven tests](data-driven-tests#beforediscovery).
 
 
 ### Variables are not available in test 


### PR DESCRIPTION
Removed one redundant instance of the word 'run', and removed another by changing to invoked, so 'Run' appears only once in the sentence.