### PR TITLE
Update vscode.mdx

### DIFF
--- a/docs/usage/vscode.mdx
+++ b/docs/usage/vscode.mdx
@@ -12,7 +12,7 @@ With Pester 5 it is finally possible to run and debug just a single test in VSCo
 
 In the latest [PowerShell](https://marketplace.visualstudio.com/items?itemName=ms-vscode.PowerShell) extension for VSCode you can enable Use Legacy Code Lens option which will enable `Run tests` on all `Describe`, `Context` and `It` blocks. You can run a whole block, any child block, or any test individually. You can also run tests that are marked as skipped by running them individually.
 
-Actually there is a bug, and the option is called Enable Legacy Code Lens, and is enabled by default and can't be disabled. 😁 Take advantage of this and go try it right now!
+Actually there is a bug, and the option is called Enable Legacy Code Lens, and is enabled by default and should be disabled for Pester 5. 😁 Take advantage of this and go try it right now!
 
 #### Output verbosity
 


### PR DESCRIPTION
Legacy Code Lens can be disabled (docs say it cannot). The excitement leads me to believe this was just a typo.

Clarified that this option should be disabled for Pester 5.