### PR TITLE
Adjust issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/docs_issue.yml
+++ b/.github/ISSUE_TEMPLATE/docs_issue.yml
@@ -16,6 +16,7 @@ body:
     - label: "Issue has a meaningful title"
       required: true
     - label: "I have searched the existing issues. See [issues](https://github.com/pester/docs/issues)"
+      required: true
 - type: input
   attributes:
     label: Link to page

--- a/.github/ISSUE_TEMPLATE/docs_issue.yml
+++ b/.github/ISSUE_TEMPLATE/docs_issue.yml
@@ -1,4 +1,4 @@
-name: DOCS 🐛 Documentation issue
+name: 🐛 Documentation issue
 description: Report an issue with the documentation at https://pester.dev
 labels: []
 body:

--- a/.github/ISSUE_TEMPLATE/docs_request.yml
+++ b/.github/ISSUE_TEMPLATE/docs_request.yml
@@ -1,4 +1,4 @@
-name: DOCS 💡 Request for new documentation
+name: 💡 Request for new documentation
 description: Missing something at https://pester.dev? Please suggest it
 labels: []
 body:


### PR DESCRIPTION
Minor updates to issue forms added in #186

- Removed prefix from template names used during testing
- Made "I have searched the existing issues" checkbox required to be consistent with other forms. It makes it "harder" to report, but upvoting existing issues will make prioritizing easier.