### PR TITLE
Use custom domain in canonical links for better SEO

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -5,7 +5,7 @@
 module.exports = {
   title: 'Pester',
   tagline: 'The ubiquitous test and mock framework for PowerShell',
-  url: 'https://pester-docs.netlify.com',
+  url: 'https://pester.dev',
   baseUrl: '/',
   baseUrlIssueBanner: true,
   favicon: 'img/favicon.ico',


### PR DESCRIPTION
Updates base url in docusaurus config to use custom domain. This is use for the `<link rel=canonical ...>` html tags to identify unique pages in search engines. Search engines should refer to custom domain.

Fix #191 