### PR TITLE
Add initial dark theme for code blocks

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -48,6 +48,7 @@ module.exports = {
     },
     prism: {
       theme: require('prism-react-renderer/themes/github'),
+      darkTheme: require('prism-react-renderer/themes/oceanicNext'),
       additionalLanguages: [
         'powershell'
       ]


### PR DESCRIPTION
Sets a dark theme used for prism codeblocks. Using the most suitable default dark theme (imo) for now.
Might want to find matching light + dark themes later (didn't have `githubDark`).

Fix #190

![image](https://user-images.githubusercontent.com/3436158/173058152-ac8e9d84-faed-445e-809e-d5fad60eeea0.png)
