### PR TITLE
Add description to static pages in v5 docs

### DIFF
--- a/docs/additional-resources/articles.mdx
+++ b/docs/additional-resources/articles.mdx
@@ -3,6 +3,7 @@ id: articles
 title: Articles
 sidebar_label: Articles
 custom_edit_url: null
+description: Published articles about using Pester for testing PowerShell code, infrastructure and more
 ---
 
 import { PesterDataTable, PesterDataButton } from "@site/src/components/PesterDataTable";

--- a/docs/additional-resources/courses.mdx
+++ b/docs/additional-resources/courses.mdx
@@ -3,6 +3,7 @@ id: courses
 title: Courses
 sidebar_label: Courses
 custom_edit_url: null
+description: List of known courses about learning and using Pester for testing PowerShell
 ---
 
 import { PesterDataTable, PesterDataButton } from "@site/src/components/PesterDataTable";

--- a/docs/additional-resources/misc.mdx
+++ b/docs/additional-resources/misc.mdx
@@ -3,6 +3,7 @@ id: misc
 title: Miscellaneous
 sidebar_label: Misc
 custom_edit_url: null
+description: Integrations, books and other resources about using Pester
 ---
 
 import { PesterDataTable, PesterDataButton } from "@site/src/components/PesterDataTable";

--- a/docs/additional-resources/projects.mdx
+++ b/docs/additional-resources/projects.mdx
@@ -3,6 +3,7 @@ id: projects
 title: Projects
 sidebar_label: Projects
 custom_edit_url: null
+description: List of third-party modules and projects that extend or compliment Pester
 ---
 
 import { PesterDataTable, PesterDataButton } from "@site/src/components/PesterDataTable";
@@ -12,6 +13,10 @@ import { columns, projects } from "./projects.table";
   columns={ columns }
   data={ projects }
 />
+
+:::note Compatibility
+Many projects above were designed for earlier versions of Pester and might not yet be updated to support Pester v5.
+:::
 
 <PesterDataButton
   text="Suggest New Project"

--- a/docs/additional-resources/videos.mdx
+++ b/docs/additional-resources/videos.mdx
@@ -3,6 +3,7 @@ id: videos
 title: Videos
 sidebar_label: Videos
 custom_edit_url: null
+description: List of videos about using Pester and PowerShell testing provided by the community
 ---
 
 import { PesterDataTable, PesterDataButton } from "@site/src/components/PesterDataTable";

--- a/docs/assertions/assertions.mdx
+++ b/docs/assertions/assertions.mdx
@@ -1,7 +1,7 @@
 ---
 id: assertions
 title: Assertion Reference
-description: Introduction to the assertion operators that comes built-in with Pester to get you started with the most common assertions
+description: Introduction to the built-in assertion operators in Pester to get you started with the most common scenarios
 ---
 
 `Should` is a command that provides assertion convenience methods for comparing objects and throwing test failures when test expectations fail. `Should` is used inside `It` blocks of a Pester test script.

--- a/docs/assertions/assertions.mdx
+++ b/docs/assertions/assertions.mdx
@@ -1,6 +1,7 @@
 ---
 id: assertions
 title: Assertion Reference
+description: Introduction to the assertion operators that comes built-in with Pester to get you started with the most common assertions
 ---
 
 `Should` is a command that provides assertion convenience methods for comparing objects and throwing test failures when test expectations fail. `Should` is used inside `It` blocks of a Pester test script.

--- a/docs/assertions/custom-assertions.mdx
+++ b/docs/assertions/custom-assertions.mdx
@@ -1,5 +1,6 @@
 ---
 title: Custom Assertions
+description: A guide for creating your own custom operators for more advanced or user-specific assertion needs
 ---
 
 Pester allows users to create their own `Should`-operators for more advanced assertions. This is done by defining a test-function and registering it with Pester using the guidelines below.

--- a/docs/assertions/should-command.mdx
+++ b/docs/assertions/should-command.mdx
@@ -1,5 +1,6 @@
 ---
 title: Should
+description: Introduction to the Should command that's used to define assertions that fails or passes the test
 ---
 
 `Should` is used to do an assertion that fails or passes the test.

--- a/docs/assertions/should-command.mdx
+++ b/docs/assertions/should-command.mdx
@@ -1,6 +1,6 @@
 ---
 title: Should
-description: Introduction to the Should command that's used to define assertions that fails or passes the test
+description: Introduction to the Should command that's used to define assertions that fail or pass the test
 ---
 
 `Should` is used to do an assertion that fails or passes the test.

--- a/docs/contributing/feature-requests.mdx
+++ b/docs/contributing/feature-requests.mdx
@@ -2,6 +2,7 @@
 id: feature-requests
 title: Feature Requests
 sidebar_label: Feature Requests
+description: How to suggest a new feature or improvement to the Pester PowerShell-module
 ---
 
 To propose a new feature, please [create a new issue](https://github.com/pester/Pester/issues/new/choose) and share as much information as you see fit. Especially what the proposed feature is, why it is useful, and what dependencies (if any) it has. It would also be great if you added one or two examples of real world usage, if you have any.

--- a/docs/contributing/introduction.mdx
+++ b/docs/contributing/introduction.mdx
@@ -1,7 +1,8 @@
 ---
 id: introduction
-title: Introduction
+title: Introduction for contributors
 sidebar_label: Introduction
+description: There are many ways to contribute to the Pester project and community. Check out this short introduction for how to get started
 ---
 
 To propose a new feature to Pester or report a bug, we encourage you to first share your findings

--- a/docs/contributing/pull-requests.mdx
+++ b/docs/contributing/pull-requests.mdx
@@ -2,6 +2,7 @@
 id: pull-requests
 title: Submitting Pull Requests
 sidebar_label: Pull Requests
+description: Introduction on how to start contributing to the Pester project either by filing a bug, feature requests, support or submitting a pull request
 ---
 
 So now we talked about your proposed change in the issue and it's time for you to implement the change and make it into a pull request (PR).

--- a/docs/contributing/reporting-issues.mdx
+++ b/docs/contributing/reporting-issues.mdx
@@ -2,7 +2,7 @@
 id: reporting-issues
 title: Reporting Issues
 sidebar_label: Reporting Issues
-description: Found an issue with Pester? Check out this guide for how to create an issue and provide us feedback so we can get help you
+description: Found an issue with Pester? Check out this guide for how to create an issue and provide us feedback so we can help you
 ---
 
 To report a bug, please [create a new issue](https://github.com/pester/Pester/issues/new/choose), and fill out the details. Your bug report should include the description of what is wrong, the version of Pester, PowerShell and the operating system. To make your bug report perfect you should also include a simple way to reproduce the bug.

--- a/docs/contributing/reporting-issues.mdx
+++ b/docs/contributing/reporting-issues.mdx
@@ -2,6 +2,7 @@
 id: reporting-issues
 title: Reporting Issues
 sidebar_label: Reporting Issues
+description: Found an issue with Pester? Check out this guide for how to create an issue and provide us feedback so we can get help you
 ---
 
 To report a bug, please [create a new issue](https://github.com/pester/Pester/issues/new/choose), and fill out the details. Your bug report should include the description of what is wrong, the version of Pester, PowerShell and the operating system. To make your bug report perfect you should also include a simple way to reproduce the bug.

--- a/docs/introduction/installation.mdx
+++ b/docs/introduction/installation.mdx
@@ -2,6 +2,7 @@
 id: installation
 title: Installation and Update
 sidebar_label: Installation
+description: Pester is a cross-platform PowerShell module for testing your PowerShell code. Follow these steps to install or update your Pester-module to get started today
 ---
 
 ## Compatibility

--- a/docs/migrations/breaking-changes-in-v5.mdx
+++ b/docs/migrations/breaking-changes-in-v5.mdx
@@ -1,7 +1,7 @@
 ---
 id: breaking-changes-in-v5
 title: Breaking changes in v5
-description: Pester v5 was a major upgrade with a new runtime. This lead to some breaking changes in syntax and features. See this list of breaking changes when upgrading to Pester v5
+description: Pester v5 included an all-new runtime which lead to some breaking changes in syntax and features for existing users. See this list of breaking changes when upgrading to Pester v5
 ---
 
 ## Actual breaking changes

--- a/docs/migrations/breaking-changes-in-v5.mdx
+++ b/docs/migrations/breaking-changes-in-v5.mdx
@@ -1,6 +1,7 @@
 ---
 id: breaking-changes-in-v5
 title: Breaking changes in v5
+description: Pester v5 was a major upgrade with a new runtime. This lead to some breaking changes in syntax and features. See this list of breaking changes when upgrading to Pester v5
 ---
 
 ## Actual breaking changes

--- a/docs/migrations/v3-to-v4.mdx
+++ b/docs/migrations/v3-to-v4.mdx
@@ -2,9 +2,10 @@
 id: v3-to-v4
 title: Migrating from Pester v3 to v4
 sidebar_label: Pester v3 to v4
+description: Migration from Pester v3 to v4 may require minor changes to your test code. See this guide to get help understanding and making the necessary changes to be compatible with Pester v4
 ---
 
-Migration from Pester 3 to 4 typically involves minor changes to test code.  Sometimes the migration requires no changes at all.  This guide is meant to help you understand and make the necessary changes to your existing test code to accommodate Pester 4.
+Migration from Pester 3 to 4 typically involves minor changes to test code. Sometimes the migration requires no changes at all. This guide is meant to help you understand and make the necessary changes to your existing test code to accommodate Pester 4.
 
 ## Update to New Names
 

--- a/docs/migrations/v4-to-v5.mdx
+++ b/docs/migrations/v4-to-v5.mdx
@@ -2,6 +2,7 @@
 id: v4-to-v5
 title: Migrating from Pester v4 to v5
 sidebar_label: Pester v4 to v5
+description: Pester v5 introduced some fundamental changes compared with Pester v4. See this guide to get help understanding and making the necessary changes to be compatible with Pester v5
 ---
 
 The fundamental change in this release is that Pester now runs in two phases: Discovery and Run. During discovery, it quickly scans your test files and discovers all the Describes, Contexts, Its and other Pester blocks.

--- a/docs/quick-start.mdx
+++ b/docs/quick-start.mdx
@@ -2,6 +2,7 @@
 id: quick-start
 title: Quick Start
 sidebar_label: Quick Start
+description: Get started using Pester to test your PowerShell scripts, functions and modules
 ---
 
 > **tl;dr:** Here is a [summary.](#summary)

--- a/docs/usage/code-coverage.mdx
+++ b/docs/usage/code-coverage.mdx
@@ -2,9 +2,10 @@
 id: code-coverage
 title: Generating Code Coverage Metrics
 sidebar_label: Code Coverage
+description: Pester can generate code coverage metrics to help you understand how many lines of your PowerShell code that is actually covered by your Pester-tests. Use this to increase confidence in your tests
 ---
 
-Code Coverage refers to the percentage of lines of code that are tested by a suite of unit tests.  It's a good general indicator of how thoroughly your code has been tested, that all branches and edge cases are working properly, etc.  Pester can generate these code coverage metrics for you while it is executing unit tests.
+Code Coverage refers to the percentage of lines of code that are tested by a suite of unit tests. It's a good general indicator of how thoroughly your code has been tested, that all branches and edge cases are working properly, etc. Pester can generate these code coverage metrics for you while it is executing unit tests.
 
 Note:  Unlike most of Pester, use of the Code Coverage feature requires PowerShell version 3.0 or later.
 

--- a/docs/usage/configuration.mdx
+++ b/docs/usage/configuration.mdx
@@ -1,6 +1,6 @@
 ---
 title: Configuration
-description: How to configure Pester's behavior, options and features
+description: Documentation about how to configure the behavior, options and features in Pester
 ---
 
 ### Advanced interface

--- a/docs/usage/configuration.mdx
+++ b/docs/usage/configuration.mdx
@@ -1,5 +1,6 @@
 ---
 title: Configuration
+description: How to configure Pester's behavior, options and features
 ---
 
 ### Advanced interface

--- a/docs/usage/data-driven-tests.mdx
+++ b/docs/usage/data-driven-tests.mdx
@@ -1,5 +1,6 @@
 ﻿---
 title: Data driven tests
+description: Pester can generate tests based on data. This can range from providing multiple examples on a single `It`, to generating whole set of tests based on an external configuration file
 ---
 
 > Migrating from Pester v4? Jump to [Migrating from Pester v4](#migrating-from-pester-v4).

--- a/docs/usage/discovery-and-run.mdx
+++ b/docs/usage/discovery-and-run.mdx
@@ -1,5 +1,6 @@
 ---
 title: Discovery and Run
+description: Pester runs your test files in two phases, Discovery and Run. This introduction explains how they work and how it affects they way your structure and write your tests
 ---
 
 Pester runs your test files in two phases: Discovery and Run. During discovery, it quickly scans your test files and discovers all the Describes, Contexts, Its and other Pester blocks.

--- a/docs/usage/file-placement-and-naming.mdx
+++ b/docs/usage/file-placement-and-naming.mdx
@@ -1,5 +1,6 @@
 ---
 title: File placement and naming
+description: Tips on how to name and structure your Pester test files and categorize your tets
 ---
 
 ## Common convention

--- a/docs/usage/file-placement-and-naming.mdx
+++ b/docs/usage/file-placement-and-naming.mdx
@@ -1,6 +1,6 @@
 ---
 title: File placement and naming
-description: Tips on how to name and structure your Pester test files and categorize your tets
+description: Tips on how to name and structure your Pester test files and categorize your tests
 ---
 
 ## Common convention

--- a/docs/usage/importing-tested-functions.mdx
+++ b/docs/usage/importing-tested-functions.mdx
@@ -1,5 +1,6 @@
 ---
 title: Importing tested functions
+description: Importing your PowerShell-code is essential to being able to test it. See how to import functions from your code to make them available for your tests
 ---
 
 > Migrating from Pester v4? Jump to [Migrating from Pester v4](#migrating-from-pester-v4).

--- a/docs/usage/mocking.mdx
+++ b/docs/usage/mocking.mdx
@@ -2,6 +2,7 @@
 id: mocking
 title: Mocking with Pester
 sidebar_label: Mocking
+description: Pester provides a set of Mocking functions making it easy to fake dependencies and also to verify behavior. Using these mocking functions can allow you to "shim" a data layer or mock other complex functions that already have their own tests
 ---
 
 Pester provides a set of Mocking functions making it easy to fake dependencies and also to verify behavior. Using these mocking functions can allow you to "shim" a data layer or mock other complex functions that already have their own tests.

--- a/docs/usage/modules.mdx
+++ b/docs/usage/modules.mdx
@@ -2,6 +2,7 @@
 id: modules
 title: Unit Testing within Modules
 sidebar_label: Modules
+description: PowerShell code in modules run in their own module state. This requires special attention when writing tests for internal functions or when mocking dependencies used by code in a module
 ---
 
 Let's say you have code like this inside a script module (.psm1 file):

--- a/docs/usage/output.mdx
+++ b/docs/usage/output.mdx
@@ -1,5 +1,6 @@
 ---
 title: Output
+description: Pester uses customizable console output to show tests results, errors and summary. See how you can customize this output to fit your preference
 ---
 
 Pester offers multiple options to customize the console output to your preference. These settings are available in the Output-section of PesterConfiguration.

--- a/docs/usage/setup-and-teardown.mdx
+++ b/docs/usage/setup-and-teardown.mdx
@@ -1,5 +1,6 @@
 ---
 title: Setup and teardown
+description: Pester offers multiple ways to run code before, and after your tests to set them up, and clean up after them
 ---
 
 ### Setup and teardown

--- a/docs/usage/skip.mdx
+++ b/docs/usage/skip.mdx
@@ -1,5 +1,6 @@
 ---
 title: Skip
+description: Skipping tests can be useful in many scenarios or when certain conditions are not met like OS-compatibility. Read about how to control this in Pester tests
 ---
 
 ### Skip on everything

--- a/docs/usage/tags.mdx
+++ b/docs/usage/tags.mdx
@@ -1,10 +1,11 @@
 ---
 title: Tags
+description: Use tags on tests and blocks to categorize code and easily choose which tests to run with simple parameters
 ---
 
 The tag parameter is now available on `Describe`, `Context` and `It` and it is possible to filter tags on any level. You can then use `-Tag` and `-ExcludeTag` to run just the tests that you want.
 
-Here you can see an example of a test suite that has acceptance tests and unit tests, and some of the tests are slow, some are flaky, and some only work on Linux. Pester5 makes running all reliable acceptance tests, that can run on Windows is as simple as:
+Here you can see an example of a test suite that has acceptance tests and unit tests, and some of the tests are slow, some are flaky, and some only work on Linux. Pester v5 makes running all reliable acceptance tests, that can run on Windows is as simple as:
 
 
 ```powershell

--- a/docs/usage/test-file-structure.mdx
+++ b/docs/usage/test-file-structure.mdx
@@ -1,5 +1,6 @@
 ﻿---
 title: Test file structure
+description: Pester uses special keywords and blocks to structure your tests like Describe, Context, It, BeforeAll/-Each etc. See this to learn how they relate and fit together
 ---
 
 Pester test files follow a similar structure. Usually there is some setup to get the tested function imported and a top-level `Describe` block to hold all the tests and child blocks. Inside that `Describe` we will find the tests themselves represented by `It` blocks. Those blocks are often grouped into their own `Describe` or `Context` based on the area of code they are testing. Those groups, can each have their own setups and teardowns represented by `BeforeAll`, `BeforeEach`, `AfterEach` and `AfterAll` blocks.

--- a/docs/usage/test-results.mdx
+++ b/docs/usage/test-results.mdx
@@ -2,9 +2,10 @@
 id: test-results
 title: Showing Test Results in CI
 sidebar_label: Test Results
+description: Pester can output tests results to NUnit and JUnit XML reports that can be consumed by test reporting tools and CI-solutions
 ---
 
-Pester can output test results to a XML file using the NUnit 2.5 schema.
+Pester can output test results to a XML file using the NUnit 2.5 or JUnit 4 schema.
 
 ## [TeamCity](https://www.jetbrains.com/teamcity/)
 

--- a/docs/usage/testdrive.mdx
+++ b/docs/usage/testdrive.mdx
@@ -2,6 +2,7 @@
 id: testdrive
 title: Isolating File Operations using the TestDrive
 sidebar_label: TestDrive
+description: TestDrive is a PowerShell PSDrive where you can create temporary files used in your tests that are automatically cleaned up after your tests are finished
 ---
 
 TestDrive is a PowerShell PSDrive for file activity limited to the scope of a block ([Describe](../commands/Describe) or [Context](../commands/Context)).

--- a/docs/usage/testregistry.mdx
+++ b/docs/usage/testregistry.mdx
@@ -2,6 +2,7 @@
 id: testregistry
 title: Isolating Windows Registry Operations using the TestRegistry
 sidebar_label: TestRegistry
+description: TestRegistry is a PowerShell PSDrive (Windows only) to help your store temporary values used in your tests in the Windows Registry that are automatically cleaned up after your tests are finished
 ---
 
 TestRegistry is a Windows-only PowerShell PSDrive used to isolate registry based tests.

--- a/docs/usage/troubleshooting.mdx
+++ b/docs/usage/troubleshooting.mdx
@@ -1,5 +1,6 @@
 ---
 title: Troubleshooting
+description: Introduction to useful logging for troubleshooting your tests or Pester itself
 ---
 
 ### Logging

--- a/docs/usage/vscode.mdx
+++ b/docs/usage/vscode.mdx
@@ -1,6 +1,6 @@
 ---
 title: VSCode
-description: See how Visual Studio Code and it's extension helps you run and debug your Pester tests directly inside the editor
+description: See how Visual Studio Code and its extensions helps you run and debug your Pester tests directly inside the editor
 ---
 
 ### VSCode improvements

--- a/docs/usage/vscode.mdx
+++ b/docs/usage/vscode.mdx
@@ -1,5 +1,6 @@
 ---
 title: VSCode
+description: See how Visual Studio Code and it's extension helps you run and debug your Pester tests directly inside the editor
 ---
 
 ### VSCode improvements


### PR DESCRIPTION
Adds a description front matter to all v5 statics pages. These are used as description in search results etc.

Related #2 