### PR TITLE
add native mock os-requirement notice

### DIFF
--- a/docs/usage/mocking.mdx
+++ b/docs/usage/mocking.mdx
@@ -170,6 +170,7 @@ Set-Alias ipj Invoke-PesterJob
 Mocking native commands can be done in a similar way as Powershell functions/cmdlets. The major difference is that native commands don't provide named parameters for us to use inside the mock scriptblock or in a ParameterFilter, so you'd have to rely on arguments made available using `$args`.
 
 ```powershell
+# For Windows-users: curl used in sample requires Windows 10 1803 / Windows Server 2019 or later
 Describe 'Mocking native commands' {
     It 'Mock bash' {
         # Windows PowerShell has curl -> Invoke-WebRequest alias. Removing to make sample cross-platform


### PR DESCRIPTION
Adding a notice about os-requirement for native mock sample to avoid future questions 🙂 

Related #208 (@bravo-kernel was too quick 🏎️ 💨)