### PR TITLE
Change github link to docs repo + fix github sponsor

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -37,7 +37,7 @@ module.exports = {
         },
         {
           label: 'GitHub',
-          href: 'https://github.com/pester/pester',
+          href: 'https://github.com/pester/docs',
           position: 'right',
         },
         {
@@ -117,7 +117,7 @@ module.exports = {
           items: [
             {
               label: 'GitHub',
-              href: 'https://github.com/pester/pester',
+              href: 'https://github.com/sponsors/nohwnd',
             },
             {
               label: 'Open Collective',


### PR DESCRIPTION
Updated the `Github` link below because it is currently pointing at the `pester/pester` repo which is unexpected and counter-intuitive.

![image](https://user-images.githubusercontent.com/230500/175776197-8fee9475-27e1-4ab6-b77e-91c60434d5e9.png)

Also updated below footer link so that it now points directly at the Github sponsor page.

![image](https://user-images.githubusercontent.com/230500/175776284-e9fb598c-94b4-436d-9caa-4ef77e47415f.png)


