### PR TITLE
Use same .editorconfig as docusaurus

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,12 +1,13 @@
 # http://editorconfig.org
-
 root = true
 
 [*]
 charset = utf-8
-end_of_line = lf
-insert_final_newline = true
 indent_style = space
-indent_size = 2
-max_line_length = 80
+insert_final_newline = true
 trim_trailing_whitespace = true
+indent_size = 4
+max_line_length = 80
+
+[*.{json,ps1xml,props,xml,yaml}]
+indent_size = 2


### PR DESCRIPTION
@fflaten I am reverting the previous changes made to `editorconfig` so we are identical to docusaurus again.

Not sure how I missed the 2-space indentation 🙄 



