### PR TITLE
Adds -SkipModuleImport to generate-command-reference script

### DIFF
--- a/generate-command-reference.ps1
+++ b/generate-command-reference.ps1
@@ -20,7 +20,9 @@ param (
 
   [Parameter(Mandatory = $False)][string] $PlatyPSVersion,
 
-  [Parameter(Mandatory = $False)][string] $DocusaurusVersion
+  [Parameter(Mandatory = $False)][string] $DocusaurusVersion,
+
+  [switch]$SkipModuleImport
 )
 Set-StrictMode -Version Latest
 $PSDefaultParameterValues['*:ErrorAction'] = "Stop"
@@ -60,8 +62,10 @@ $ModuleList.Keys.Clone() | ForEach-Object {
     Install-Module $ModuleName -RequiredVersion $RequestedVersion -Force -SkipPublisherCheck -AllowClobber -Scope CurrentUser
   }
 
-  Write-Host "=> importing"
-  Import-Module -Name $ModuleName -RequiredVersion $RequestedVersion -Force
+  if ($SkipModuleImport -eq $false) {
+    Write-Host "=> importing"
+    Import-Module -Name $ModuleName -RequiredVersion $RequestedVersion -Force
+  }
 }
 
 # -----------------------------------------------------------------------------

--- a/generate-command-reference.ps1
+++ b/generate-command-reference.ps1
@@ -62,7 +62,7 @@ $ModuleList.Keys.Clone() | ForEach-Object {
     Install-Module $ModuleName -RequiredVersion $RequestedVersion -Force -SkipPublisherCheck -AllowClobber -Scope CurrentUser
   }
 
-  if ($SkipModuleImport -eq $false) {
+  if (-not $SkipModuleImport) {
     Write-Host "=> importing"
     Import-Module -Name $ModuleName -RequiredVersion $RequestedVersion -Force
   }


### PR DESCRIPTION
Adds `-SkipModuleImport` switch to make development and debugging workflows quicker.

Especially useful when e.g. developing the Alt3-module against Pester because this prevents the script from importing the PSGallery version instead of using the freshly-built version available in the session:

```
cd Alt3.Docusaurus.Powershell
.\build-module.ps1
cd ..\pester-docs\
.\generate-command-reference.ps1 -SkipModuleImport
```

Added here as well: https://docusaurus-powershell.netlify.app/docs/contributing#example