### PR TITLE
Add note about scope for script parameters

### DIFF
--- a/docs/usage/data-driven-tests.mdx
+++ b/docs/usage/data-driven-tests.mdx
@@ -369,7 +369,7 @@ $x = 1
 
 ## Providing external data to tests
 
-`.Tests.ps1` script is a PowerShell script as any other and you can use the `param` block in it. This is very useful when reusing a single test file with multiple data sets. For example when writing a generic test suite that ensures that correct style is used in a given script file:
+`.Tests.ps1` script is a PowerShell script as any other and you can use the `param` block in it. Script parameters are available in both `Discovery` and `Run`. This is very useful when reusing a single test file with multiple data sets. For example when writing a generic test suite that ensures that correct style is used in a given script file:
 
 ```powershell
 # in CodingStyle.Tests.ps1


### PR DESCRIPTION
Add a note that script parameters are available in both Discovery and Run-phase. In Pester 5.3+ even unspecified parameters with default-values are available.

This is the only way to define variables that are available in root-level `BeforeAll`-blocks.
Related https://github.com/pester/Pester/issues/1708#issuecomment-1204270696