### PR TITLE
Add theme-color meta tag for navbar color

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -14,6 +14,12 @@ module.exports = {
   onBrokenLinks: 'warn',
   onBrokenMarkdownLinks: 'warn',
   themeConfig: {
+    metadata: [
+        {
+            name: 'theme-color',
+            content: '#0072c6'
+        }
+    ],
     navbar: {
       title: 'Pester',
       logo: {


### PR DESCRIPTION
Sets `theme-color` meta tag to Pester-blue color to match header.
This is often used for navbar-color, ex. in Safari 15 (MacOS and iOS), PWA etc.

Fix #225 