### PR TITLE
Use light text for hero title in dark mode

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -154,13 +154,6 @@ table {
   overflow-x: auto;
 }
 
-@media only screen and (max-width: 768px) {
-  .hero .hero__title {
-    font-size: 36px;
-    text-align: center;
-  }
-}
-
 @media (max-width: 996px) {
   .footer .row .col.col.col {
     flex: 1 0 !important;

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -76,7 +76,7 @@ function Home() {
         <div className={classnames('container', styles.container)}>
           <div className="row">
             <div className={classnames('col col--9', styles.heroContent)}>
-              <h1 className="hero__title">The test framework for Powershell</h1>
+              <h1 className={classnames('hero__title', styles.heroTitle)}>The test framework for Powershell</h1>
               <p className="hero__subtitle">Pester is the ubiquitous test and mock framework for PowerShell</p>
 
               <div className={styles.buttons}>

--- a/src/pages/styles.module.css
+++ b/src/pages/styles.module.css
@@ -17,7 +17,7 @@
 }
 
 html[data-theme='dark'] .heroBanner {
-  color: #000;
+  --ifm-hero-text-color: var(--ifm-font-color-base);
 }
 
 .heroLogo img {

--- a/src/pages/styles.module.css
+++ b/src/pages/styles.module.css
@@ -34,6 +34,13 @@ html[data-theme='dark'] .heroBanner {
   }
 }
 
+@media only screen and (max-width: 768px) {
+  .heroTitle {
+    font-size: 36px;
+    text-align: center;
+  }
+}
+
 .buttons {
   display: flex;
   align-items: center;


### PR DESCRIPTION
Suggest to keep hero title light even in dark mode.

Before:
![before](https://user-images.githubusercontent.com/3436158/188289611-b8a153dc-a772-4193-a122-419bb6672a7b.png)

After:
![after](https://user-images.githubusercontent.com/3436158/188289606-a34e6d5d-836d-477b-8d50-a867abd6bf31.png)

Also moves hero-specific styling to main page css module where the rest is.