### PR TITLE
Fix typo in install.mdx

### DIFF
--- a/docs/introduction/installation.mdx
+++ b/docs/introduction/installation.mdx
@@ -39,7 +39,7 @@ WARNING: Source location 'https://www.powershellgallery.com/api/v2/packages/Pest
 To enable TLS 1.2 for the current PowerShell instance, you can run the following code, and then re-run the installation command:
 
 ```powershell
-[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocol]::Tls12
+[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
 ```
 
 ### Removing the Built-In Version of Pester


### PR DESCRIPTION
cf. https://learn.microsoft.com/fr-fr/dotnet/api/system.net.securityprotocoltype?view=netframework-4.5.2

The value previously written `[System.Net.SecurityProtocol]::Tls12` doesn't seem to exist:

```
> [System.Net.SecurityProtocol]::Tls12
Unable to find type [System.Net.SecurityProtocol].
At line:1 char:1
+ [System.Net.SecurityProtocol]::Tls12
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (System.Net.SecurityProtocol:TypeName) [], RuntimeException
    + FullyQualifiedErrorId : TypeNotFound
```

... so it must have been a typo.