### PR TITLE
Add netlify redirects for common GitHub links

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -1,0 +1,4 @@
+# GitHub redirects
+/issues                 https://github.com/pester/pester/issues/new/choose
+/issues/docs            https://github.com/pester/docs/issues/new/choose
+/releases/:v            https://github.com/pester/pester/releases/tag/:v


### PR DESCRIPTION
Add redirects for easier link sharing to common GitHub pages.

Ex. `https://pester.dev/releases/5.4.0`