### PR TITLE
Misc codeblock and whitespace cleanup

### DIFF
--- a/docs/quick-start.mdx
+++ b/docs/quick-start.mdx
@@ -162,7 +162,6 @@ This will break the assertion that we have in our test, because we no longer ret
 ```
 Invoke-Pester -Output Detailed C:\t\Planets\Get-Planet.Tests.ps1
 
-
 Starting discovery in 1 files.
 Discovering in C:\t\Planets\Get-Planet.Tests.ps1.
 Found 1 tests. 9ms
@@ -202,7 +201,6 @@ If you look closer on how we broke the test, you can see that there are two dist
 - The second one is when the function works correctly, but the test is incorrect. This is a bad way to break the test.
 
 Being able to distinguish between those two is important, when your test breaks keep in mind that either the function, or the tests might be broken. What you usually do is that you look at what changed more recently. If the test is new, and the function existed for a while, you first blame the test. When the test was passing before, but it is not anymore, you first blame the tested function.
-
 
 ## Other keywords
 
@@ -248,8 +246,7 @@ Until now we had just a single file that contained both our tests and the functi
 
 To move the function out of the test we will move it to a separate file, and will [dot-source](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_scripts?view=powershell-7#script-scope-and-dot-sourcing) it back into the `BeforeAll`. To do this create a new file in the same directory as `Get-Planet.Tests.ps1` and call it `Get-Planet.ps1`. Then cut the function from the test file and paste it into the other file:
 
-```powershell
-# in file Get-Planet.ps1
+```powershell title="Get-Planet.ps1"
 function Get-Planet ([string]$Name = '*') {
     $planets = @(
         @{ Name = 'Mercury' }
@@ -266,8 +263,7 @@ function Get-Planet ([string]$Name = '*') {
 }
 ```
 
-```powershell
-# in file Get-Planet.Tests.ps1
+```powershell title="Get-Planet.Tests.ps1"
 BeforeAll {
 
 }
@@ -318,7 +314,6 @@ Describe 'Get-Planet' {
 
 ```
 Invoke-Pester -Output Detailed C:\t\Planets\Get-Planet.Tests.ps1
-
 
 Starting discovery in 1 files.
 Discovering in C:\t\Planets\Get-Planet.Tests.ps1.

--- a/docs/usage/code-coverage.mdx
+++ b/docs/usage/code-coverage.mdx
@@ -23,9 +23,9 @@ The hashtables may have the following keys:
 
 After `Invoke-Pester` finishes executing the test scripts, Pester will output a coverage report to the console.  If you are using `Invoke-Pester`'s `-PassThru` switch, the coverage analysis will also be available on the output object, under its `CodeCoverage` property.
 
-Here are some examples of the various ways the `-CodeCoverage` parameter can be used, and their corresponding output.  Here is the CoverageTest.ps1 script file:
+Here are some examples of the various ways the `-CodeCoverage` parameter can be used, and their corresponding output when used with the following files.
 
-```powershell
+```powershell title="CoverageTest.ps1"
 function FunctionOne ([switch] $SwitchParam)
 {
     if ($SwitchParam)
@@ -45,9 +45,7 @@ function FunctionTwo
 }
 ```
 
-And here is CoverageTest.Tests.ps1:
-
-```powershell
+```powershell title="CoverageTest.Tests.ps1"
 $here = Split-Path -Parent $MyInvocation.MyCommand.Path
 $sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -replace '\.Tests\.', '.'
 . "$here\$sut"
@@ -63,7 +61,7 @@ Describe 'Demonstrating Code Coverage' {
 }
 ```
 
-As you can see, the test script fails to run FunctionOne with its switch parameter set, and there is an unreachable line of code in FunctionTwo.  Here are the results of calling `Invoke-Pester` with different values passed to its `-CodeCoverage` parameter:
+As you can see, the test script fails to run FunctionOne with its switch parameter set, and there is an unreachable line of code in FunctionTwo. Here are the results of calling `Invoke-Pester` with different values passed to its `-CodeCoverage` parameter:
 
 ```powershell
 Invoke-Pester .\CoverageTest.Tests.ps1 -CodeCoverage .\CoverageTest.ps1

--- a/docs/usage/code-coverage.mdx
+++ b/docs/usage/code-coverage.mdx
@@ -7,21 +7,21 @@ description: Pester can generate code coverage metrics to help you understand ho
 
 Code Coverage refers to the percentage of lines of code that are tested by a suite of unit tests. It's a good general indicator of how thoroughly your code has been tested, that all branches and edge cases are working properly, etc. Pester can generate these code coverage metrics for you while it is executing unit tests.
 
-Note:  Unlike most of Pester, use of the Code Coverage feature requires PowerShell version 3.0 or later.
+Note: Unlike most of Pester, use of the Code Coverage feature requires PowerShell version 3.0 or later.
 
-To generate Code Coverage metrics, pass one or more values to the `-CodeCoverage` parameter of the `Invoke-Pester` command.  The arguments to this parameter may be one of the following:
+To generate Code Coverage metrics, pass one or more values to the `-CodeCoverage` parameter of the `Invoke-Pester` command. The arguments to this parameter may be one of the following:
 
-1. Strings, which refer to the path of the script files for which you want to generate coverage metrics.  These strings may contain wildcards.
-2. Hashtables, which give you finer control over which sections of the file are analyzed for coverage.  Using these hashtables, you may limit the analysis to specific functions or ranges of lines within a file.
+1. Strings, which refer to the path of the script files for which you want to generate coverage metrics. These strings may contain wildcards.
+2. Hashtables, which give you finer control over which sections of the file are analyzed for coverage. Using these hashtables, you may limit the analysis to specific functions or ranges of lines within a file.
 
 The hashtables may have the following keys:
 
-- `Path` or `p`:  Path to the file on disk.  This is the only required key in the hashtable, and passing a hashtable which contains only this key is the equivalent of just passing path as a string value to the `-CodeCoverage` parameter.  As with passing strings to this parameter, the `Path` key may contain wildcards.
-- `Function` or `f`: The name of a function you wish to analyze within a file.  This value may contain wildcards, and any matching functions will be analyzed.  If this key is used, `StartLine` and `EndLine` are ignored for this particular hashtable.
-- `StartLine` or `s`:  The first line of a range to be analyzed.  If this key is used and no corresponding value is assigned to `EndLine`, then the entire remainder of the file starting with `StartLine` will be analyzed.
-- `EndLine` or `e`:  The last line of a range to be analyzed.  If this key is used and no corresponding value is assigned to `StartLine`, the entire file up to and including `EndLine` will be analyzed.
+- `Path` or `p`: Path to the file on disk. This is the only required key in the hashtable, and passing a hashtable which contains only this key is the equivalent of just passing path as a string value to the `-CodeCoverage` parameter. As with passing strings to this parameter, the `Path` key may contain wildcards.
+- `Function` or `f`: The name of a function you wish to analyze within a file. This value may contain wildcards, and any matching functions will be analyzed. If this key is used, `StartLine` and `EndLine` are ignored for this particular hashtable.
+- `StartLine` or `s`: The first line of a range to be analyzed. If this key is used and no corresponding value is assigned to `EndLine`, then the entire remainder of the file starting with `StartLine` will be analyzed.
+- `EndLine` or `e`: The last line of a range to be analyzed. If this key is used and no corresponding value is assigned to `StartLine`, the entire file up to and including `EndLine` will be analyzed.
 
-After `Invoke-Pester` finishes executing the test scripts, Pester will output a coverage report to the console.  If you are using `Invoke-Pester`'s `-PassThru` switch, the coverage analysis will also be available on the output object, under its `CodeCoverage` property.
+After `Invoke-Pester` finishes executing the test scripts, Pester will output a coverage report to the console. If you are using `Invoke-Pester`'s `-PassThru` switch, the coverage analysis will also be available on the output object, under its `CodeCoverage` property.
 
 Here are some examples of the various ways the `-CodeCoverage` parameter can be used, and their corresponding output when used with the following files.
 
@@ -61,7 +61,7 @@ Describe 'Demonstrating Code Coverage' {
 }
 ```
 
-As you can see, the test script fails to run FunctionOne with its switch parameter set, and there is an unreachable line of code in FunctionTwo. Here are the results of calling `Invoke-Pester` with different values passed to its `-CodeCoverage` parameter:
+As you can see, the test script fails to run `FunctionOne` with its switch parameter set, and there is an unreachable line of code in `FunctionTwo`. Here are the results of calling `Invoke-Pester` with different values passed to its `-CodeCoverage` parameter:
 
 ```powershell
 Invoke-Pester .\CoverageTest.Tests.ps1 -CodeCoverage .\CoverageTest.ps1
@@ -122,6 +122,6 @@ Then, add a Publish Code Coverage Result task to your pipeline. It is important 
 ```
 ---
 
-A quick note on the "analyzed commands" numbers.  You may have noticed that even though CoverageTest.ps1 is 17 lines long, Pester reports that only 5 commands are being analyzed for coverage.  This is a limitation of the current implementation of the coverage analysis, which uses PSBreakpoints to track which commands are executed.  Breakpoints can only be triggered by _commands_ in PowerShell, which includes both calls to functions, Cmdlets and programs, as well as expressions and variable assignments.  Breakpoints are not triggered by keywords such as `else`, `try`, or `finally`, or on opening or closing braces, but breakpoints can be triggered by expressions passed to certain keywords, such as the conditions evaluated by `if` statements and the various loop constructs, `throw` and `return` statements which are passed a value, and so on.  In the example script, the 5 analyzed commands are the expression evaluated by the `if` statement in FunctionOne, and the expressions after each of the four `return` statements.  (Note that the `return` keyword itself does not trigger the breakpoint, so Pester would not report coverage analysis for a `return` statement which is not passed a value.)
+A quick note on the "analyzed commands" numbers. You may have noticed that even though CoverageTest.ps1 is 17 lines long, Pester reports that only 5 commands are being analyzed for coverage. This is a limitation of the current implementation of the coverage analysis, which uses PSBreakpoints to track which commands are executed. Breakpoints can only be triggered by _commands_ in PowerShell, which includes both calls to functions, Cmdlets and programs, as well as expressions and variable assignments. Breakpoints are not triggered by keywords such as `else`, `try`, or `finally`, or on opening or closing braces, but breakpoints can be triggered by expressions passed to certain keywords, such as the conditions evaluated by `if` statements and the various loop constructs, `throw` and `return` statements which are passed a value, and so on. In the example script, the 5 analyzed commands are the expression evaluated by the `if` statement in `FunctionOne`, and the expressions after each of the four `return` statements. (Note that the `return` keyword itself does not trigger the breakpoint, so Pester would not report coverage analysis for a `return` statement which is not passed a value.)
 
-In practice, these limitations don't matter much.  There are enough commands in a PowerShell script to trigger breakpoints and make it clear which branches and edge cases have been tested, even if not every line is capable of being part of the analysis.
+In practice, these limitations don't matter much. There are enough commands in a PowerShell script to trigger breakpoints and make it clear which branches and edge cases have been tested, even if not every line is capable of being part of the analysis.

--- a/docs/usage/configuration.mdx
+++ b/docs/usage/configuration.mdx
@@ -33,7 +33,9 @@ $configuration.Filter.Tag = 'Acceptance'
 $configuration.Filter.ExcludeTag = 'WindowsOnly'
 $configuration.Should.ErrorAction = 'Continue'
 $configuration.CodeCoverage.Enabled = $true
+```
 
+```powershell
 # cast whole hashtable to configuration
 $configuration = [PesterConfiguration]@{
     Run = @{
@@ -50,7 +52,9 @@ $configuration = [PesterConfiguration]@{
         Enabled = $true
     }
 }
+```
 
+```powershell
 # cast from empty hashtable to get default
 $configuration = [PesterConfiguration]@{}
 $configuration.Run.Path = 'C:\projects\tst'

--- a/docs/usage/data-driven-tests.mdx
+++ b/docs/usage/data-driven-tests.mdx
@@ -371,9 +371,7 @@ $x = 1
 
 `.Tests.ps1` script is a PowerShell script as any other and you can use the `param` block in it. Script parameters are available in both `Discovery` and `Run`. This is very useful when reusing a single test file with multiple data sets. For example when writing a generic test suite that ensures that correct style is used in a given script file:
 
-```powershell
-# in CodingStyle.Tests.ps1
-
+```powershell title="CodingStyle.Tests.ps1"
 param (
     [Parameter(Mandatory)]
     [string] $File

--- a/docs/usage/importing-tested-functions.mdx
+++ b/docs/usage/importing-tested-functions.mdx
@@ -12,8 +12,8 @@ Pester tests are placed in `.Tests.ps1` file, for example `Get-Emoji.Tests.ps1`.
 
 To make the tested code available to the test we need to import the code file. This is done by dot-sourcing the file into the current scope like this:
 
-```powershell
-# at the top of Get-Emoji.Tests.ps1
+```powershell title="Get-Emoji.Tests.ps1"
+# at the top of the file
 BeforeAll {
     . $PSScriptRoot/Get-Emoji.ps1
 }
@@ -23,7 +23,7 @@ This code will locate the `Get-Emoji.ps1` file, which is placed in the same dire
 
 Alternatively `$PSCommandPath` can be used to get the name of the code file by convention:
 
-```powershell
+```powershell title="Get-Emoji.Tests.ps1"
 BeforeAll {
     # Get-Emoji.Tests.ps1 - .Tests.ps1 + .ps1 = Get-Emoji.ps1
     . $PSCommandPath.Replace('.Tests.ps1','.ps1')
@@ -61,7 +61,7 @@ Describe "Get-Cactus" {
 ```
 
 ```powershell
-AFTER (Pester v5):
+# AFTER (Pester v5):
 
 BeforeAll {
     # DON'T use $MyInvocation.MyCommand.Path

--- a/docs/usage/modules.mdx
+++ b/docs/usage/modules.mdx
@@ -7,7 +7,7 @@ description: PowerShell code in modules run in their own module state. This requ
 
 Let's say you have code like this inside a script module (.psm1 file):
 
-```powershell
+```powershell title="MyModule.psm1"
 function BuildIfChanged {
     $thisVersion = Get-Version
     $nextVersion = Get-NextVersion
@@ -31,7 +31,7 @@ Export-ModuleMember -Function BuildIfChanged
 
 You wish to write a unit test for this module which mocks the calls to `Get-Version` and `Get-NextVersion` from the module's `BuildIfChanged` command. In older versions of Pester, this was not possible. As of version 3.0, there are two ways you can perform unit tests of PowerShell script modules. The first is to inject mocks into a module:
 
-For these example, we'll assume that the PSM1 file is named "MyModule.psm1", and that it is installed on your PSModulePath.
+For these example, we'll assume that the PSM1 file is named `MyModule.psm1`, and that it is installed on your PSModulePath.
 
 ```powershell
 BeforeAll {

--- a/versioned_docs/version-v4/usage/code-coverage.mdx
+++ b/versioned_docs/version-v4/usage/code-coverage.mdx
@@ -4,27 +4,27 @@ title: Generating Code Coverage Metrics
 sidebar_label: Code Coverage
 ---
 
-Code Coverage refers to the percentage of lines of code that are tested by a suite of unit tests.  It's a good general indicator of how thoroughly your code has been tested, that all branches and edge cases are working properly, etc.  Pester can generate these code coverage metrics for you while it is executing unit tests.
+Code Coverage refers to the percentage of lines of code that are tested by a suite of unit tests. It's a good general indicator of how thoroughly your code has been tested, that all branches and edge cases are working properly, etc. Pester can generate these code coverage metrics for you while it is executing unit tests.
 
-Note:  Unlike most of Pester, use of the Code Coverage feature requires PowerShell version 3.0 or later.
+Note: Unlike most of Pester, use of the Code Coverage feature requires PowerShell version 3.0 or later.
 
-To generate Code Coverage metrics, pass one or more values to the `-CodeCoverage` parameter of the `Invoke-Pester` command.  The arguments to this parameter may be one of the following:
+To generate Code Coverage metrics, pass one or more values to the `-CodeCoverage` parameter of the `Invoke-Pester` command. The arguments to this parameter may be one of the following:
 
-1. Strings, which refer to the path of the script files for which you want to generate coverage metrics.  These strings may contain wildcards.
-2. Hashtables, which give you finer control over which sections of the file are analyzed for coverage.  Using these hashtables, you may limit the analysis to specific functions or ranges of lines within a file.
+1. Strings, which refer to the path of the script files for which you want to generate coverage metrics. These strings may contain wildcards.
+2. Hashtables, which give you finer control over which sections of the file are analyzed for coverage. Using these hashtables, you may limit the analysis to specific functions or ranges of lines within a file.
 
 The hashtables may have the following keys:
 
-- `Path` or `p`:  Path to the file on disk.  This is the only required key in the hashtable, and passing a hashtable which contains only this key is the equivalent of just passing path as a string value to the `-CodeCoverage` parameter.  As with passing strings to this parameter, the `Path` key may contain wildcards.
-- `Function` or `f`: The name of a function you wish to analyze within a file.  This value may contain wildcards, and any matching functions will be analyzed.  If this key is used, `StartLine` and `EndLine` are ignored for this particular hashtable.
-- `StartLine` or `s`:  The first line of a range to be analyzed.  If this key is used and no corresponding value is assigned to `EndLine`, then the entire remainder of the file starting with `StartLine` will be analyzed.
-- `EndLine` or `e`:  The last line of a range to be analyzed.  If this key is used and no corresponding value is assigned to `StartLine`, the entire file up to and including `EndLine` will be analyzed.
+- `Path` or `p`: Path to the file on disk. This is the only required key in the hashtable, and passing a hashtable which contains only this key is the equivalent of just passing path as a string value to the `-CodeCoverage` parameter. As with passing strings to this parameter, the `Path` key may contain wildcards.
+- `Function` or `f`: The name of a function you wish to analyze within a file. This value may contain wildcards, and any matching functions will be analyzed. If this key is used, `StartLine` and `EndLine` are ignored for this particular hashtable.
+- `StartLine` or `s`: The first line of a range to be analyzed. If this key is used and no corresponding value is assigned to `EndLine`, then the entire remainder of the file starting with `StartLine` will be analyzed.
+- `EndLine` or `e`: The last line of a range to be analyzed. If this key is used and no corresponding value is assigned to `StartLine`, the entire file up to and including `EndLine` will be analyzed.
 
-After `Invoke-Pester` finishes executing the test scripts, Pester will output a coverage report to the console.  If you are using `Invoke-Pester`'s `-PassThru` switch, the coverage analysis will also be available on the output object, under its `CodeCoverage` property.
+After `Invoke-Pester` finishes executing the test scripts, Pester will output a coverage report to the console. If you are using `Invoke-Pester`'s `-PassThru` switch, the coverage analysis will also be available on the output object, under its `CodeCoverage` property.
 
-Here are some examples of the various ways the `-CodeCoverage` parameter can be used, and their corresponding output.  Here is the CoverageTest.ps1 script file:
+Here are some examples of the various ways the `-CodeCoverage` parameter can be used, and their corresponding output when used with the following files.
 
-```powershell
+```powershell title="CoverageTest.ps1"
 function FunctionOne ([switch] $SwitchParam)
 {
     if ($SwitchParam)
@@ -44,9 +44,7 @@ function FunctionTwo
 }
 ```
 
-And here is CoverageTest.Tests.ps1:
-
-```powershell
+```powershell title="CoverageTest.Tests.ps1"
 $here = Split-Path -Parent $MyInvocation.MyCommand.Path
 $sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path) -replace '\.Tests\.', '.'
 . "$here\$sut"
@@ -62,7 +60,7 @@ Describe 'Demonstrating Code Coverage' {
 }
 ```
 
-As you can see, the test script fails to run FunctionOne with its switch parameter set, and there is an unreachable line of code in FunctionTwo.  Here are the results of calling `Invoke-Pester` with different values passed to its `-CodeCoverage` parameter:
+As you can see, the test script fails to run `FunctionOne` with its switch parameter set, and there is an unreachable line of code in `FunctionTwo`. Here are the results of calling `Invoke-Pester` with different values passed to its `-CodeCoverage` parameter:
 
 ```powershell
 Invoke-Pester .\CoverageTest.Tests.ps1 -CodeCoverage .\CoverageTest.ps1
@@ -101,6 +99,6 @@ Covered 100.00 % of 1 analyzed command in 1 file.
 ```
 
 ---
-A quick note on the "analyzed commands" numbers.  You may have noticed that even though CoverageTest.ps1 is 17 lines long, Pester reports that only 5 commands are being analyzed for coverage.  This is a limitation of the current implementation of the coverage analysis, which uses PSBreakpoints to track which commands are executed.  Breakpoints can only be triggered by _commands_ in PowerShell, which includes both calls to functions, Cmdlets and programs, as well as expressions and variable assignments.  Breakpoints are not triggered by keywords such as `else`, `try`, or `finally`, or on opening or closing braces, but breakpoints can be triggered by expressions passed to certain keywords, such as the conditions evaluated by `if` statements and the various loop constructs, `throw` and `return` statements which are passed a value, and so on.  In the example script, the 5 analyzed commands are the expression evaluated by the `if` statement in FunctionOne, and the expressions after each of the four `return` statements.  (Note that the `return` keyword itself does not trigger the breakpoint, so Pester would not report coverage analysis for a `return` statement which is not passed a value.)
+A quick note on the "analyzed commands" numbers. You may have noticed that even though CoverageTest.ps1 is 17 lines long, Pester reports that only 5 commands are being analyzed for coverage. This is a limitation of the current implementation of the coverage analysis, which uses PSBreakpoints to track which commands are executed. Breakpoints can only be triggered by _commands_ in PowerShell, which includes both calls to functions, Cmdlets and programs, as well as expressions and variable assignments. Breakpoints are not triggered by keywords such as `else`, `try`, or `finally`, or on opening or closing braces, but breakpoints can be triggered by expressions passed to certain keywords, such as the conditions evaluated by `if` statements and the various loop constructs, `throw` and `return` statements which are passed a value, and so on. In the example script, the 5 analyzed commands are the expression evaluated by the `if` statement in `FunctionOne`, and the expressions after each of the four `return` statements. (Note that the `return` keyword itself does not trigger the breakpoint, so Pester would not report coverage analysis for a `return` statement which is not passed a value.)
 
-In practice, these limitations don't matter much.  There are enough commands in a PowerShell script to trigger breakpoints and make it clear which branches and edge cases have been tested, even if not every line is capable of being part of the analysis.
+In practice, these limitations don't matter much. There are enough commands in a PowerShell script to trigger breakpoints and make it clear which branches and edge cases have been tested, even if not every line is capable of being part of the analysis.

--- a/versioned_docs/version-v4/usage/modules.mdx
+++ b/versioned_docs/version-v4/usage/modules.mdx
@@ -6,7 +6,7 @@ sidebar_label: Modules
 
 Let's say you have code like this inside a script module (.psm1 file):
 
-```powershell
+```powershell title="MyModule.psm1"
 function BuildIfChanged {
     $thisVersion = Get-Version
     $nextVersion = Get-NextVersion
@@ -30,7 +30,7 @@ Export-ModuleMember -Function BuildIfChanged
 
 You wish to write a unit test for this module which mocks the calls to `Get-Version` and `Get-NextVersion` from the module's `BuildIfChanged` command.  In older versions of Pester, this was not possible.  As of version 3.0, there are two ways you can perform unit tests of PowerShell script modules.  The first is to inject mocks into a module:
 
-For these example, we'll assume that the PSM1 file is named "MyModule.psm1", and that it is installed on your PSModulePath.
+For these example, we'll assume that the PSM1 file is named `MyModule.psm1`, and that it is installed on your PSModulePath.
 
 ```powershell
 Import-Module MyModule


### PR DESCRIPTION
Minor cleanup in codeblocks and whitespace. Related #271 - apparently there were more codeblocks to fix.
Review with ignore whitespace.