### PR TITLE
Fix wrapped dates in data tables

### DIFF
--- a/docs/additional-resources/articles.table.js
+++ b/docs/additional-resources/articles.table.js
@@ -422,6 +422,6 @@ export const columns = [
   {
     header: "Date",
     accessorKey: "date",
-    className: "pester-data-table",
+    className: "pester-data-table nowrap",
   },
 ];

--- a/docs/additional-resources/misc.table.js
+++ b/docs/additional-resources/misc.table.js
@@ -46,6 +46,6 @@ export const columns = [
   {
     header: "Date",
     accessorKey: "date",
-    className: "pester-data-table",
+    className: "pester-data-table nowrap",
   },
 ];

--- a/docs/additional-resources/videos.table.js
+++ b/docs/additional-resources/videos.table.js
@@ -82,6 +82,6 @@ export const columns = [
   {
     header: "Date",
     accessorKey: "date",
-    className: "pester-data-table",
+    className: "pester-data-table nowrap",
   },
 ];

--- a/src/components/PesterDataTable/style.css
+++ b/src/components/PesterDataTable/style.css
@@ -6,6 +6,10 @@
   text-align: right;
 }
 
+.pester-data-table.nowrap {
+  white-space: nowrap;
+}
+
 .pester-data-table, .pester-data-table.center {
   text-align: center;
 }

--- a/versioned_docs/version-v4/additional-resources/articles.table.js
+++ b/versioned_docs/version-v4/additional-resources/articles.table.js
@@ -422,6 +422,6 @@ export const columns = [
   {
     header: "Date",
     accessorKey: "date",
-    className: "pester-data-table",
+    className: "pester-data-table nowrap",
   },
 ];

--- a/versioned_docs/version-v4/additional-resources/misc.table.js
+++ b/versioned_docs/version-v4/additional-resources/misc.table.js
@@ -46,6 +46,6 @@ export const columns = [
   {
     header: "Date",
     accessorKey: "date",
-    className: "pester-data-table",
+    className: "pester-data-table nowrap",
   },
 ];

--- a/versioned_docs/version-v4/additional-resources/videos.table.js
+++ b/versioned_docs/version-v4/additional-resources/videos.table.js
@@ -64,6 +64,6 @@ export const columns = [
   {
     header: "Date",
     accessorKey: "date",
-    className: "pester-data-table",
+    className: "pester-data-table nowrap",
   },
 ];


### PR DESCRIPTION
Avoid wrapping date columns in Additional Resourced data tables.

Before:
![image](https://github.com/pester/docs/assets/3436158/86b8be3f-13ad-435a-ad83-d58ad3cb2fdc)

After:
![image](https://github.com/pester/docs/assets/3436158/ce3fbcd3-d09f-4061-b019-0b9de7715996)
