### PR TITLE
Respect current version in navbar links

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -36,13 +36,15 @@ module.exports = {
           position: 'left',
         },
         {
+          type: 'doc',
           label: 'Docs',
-          to: 'docs/quick-start',
+          docId: 'quick-start',
           position: 'right'
         },
         {
+          type: 'doc',
           label: 'Commands',
-          to: 'docs/commands/Add-ShouldOperator',
+          docId: 'commands/Add-ShouldOperator',
           position: 'right'
         },
         {

--- a/versioned_docs/version-v4/commands/Add-AssertionOperator.mdx
+++ b/versioned_docs/version-v4/commands/Add-AssertionOperator.mdx
@@ -1,5 +1,8 @@
 ---
-id: Add-AssertionOperator
+# Override id to have common docId for Commands navbar-link for all versions
+id: Add-ShouldOperator
+# Override slug so url matches v4 name
+slug: Add-AssertionOperator
 title: Add-AssertionOperator
 description: Help page for the Powershell Pester "Add-AssertionOperator" command
 keywords:

--- a/versioned_sidebars/version-v4-sidebars.json
+++ b/versioned_sidebars/version-v4-sidebars.json
@@ -122,7 +122,7 @@
       "items": [
         {
           "type": "doc",
-          "id": "commands/Add-AssertionOperator"
+          "id": "commands/Add-ShouldOperator"
         },
         {
           "type": "doc",


### PR DESCRIPTION
While browsing v4 docs the "Docs" and "Commands" navbar links still pointed to v5. Could cause confusion when clicking Commands which would should incompatible v5 commands.

PR changes the navbar links to version-aware doc-links.