### PR TITLE
Fix installation commands for v4

### DIFF
--- a/versioned_docs/version-v4/introduction/installation.mdx
+++ b/versioned_docs/version-v4/introduction/installation.mdx
@@ -125,13 +125,7 @@ PSGallery is the easiest way to get Pester installed to your computer, but there
 Chocolatey (or choco) is the easiest way to [get Pester running on AppVeyor](https://github.com/pester/Pester#build-server-integration). You avoid setting up PowerShellGet and it also supports pre-release versions.
 
 ```powershell
-choco install Pester
-```
-
-Or to update:
-
-```powershell
-choco install Pester --prerelease
+choco install Pester --version=4.10.1
 ```
 
 ### Nuget

--- a/versioned_docs/version-v4/introduction/installation.mdx
+++ b/versioned_docs/version-v4/introduction/installation.mdx
@@ -19,7 +19,7 @@ Instead you need to perform a new side-by-side installation of Pester, because `
 Here's the command you need to run _as administrator_ in order to get the latest version of Pester:
 
 ```powershell
-Install-Module -Name Pester -Force
+Install-Module -Name Pester -MaximumVersion 4.99 -Force
 ```
 
 Installing the module may result in this message:
@@ -42,13 +42,13 @@ icacls $module /reset
 icacls $module /grant "*S-1-5-32-544:F" /inheritance:d /T
 Remove-Item -Path $module -Recurse -Force -Confirm:$false
 
-Install-Module -Name Pester -Force
+Install-Module -Name Pester  -MaximumVersion 4.99 -Force
 ```
 
 For any subsequent update it is enough to run:
 
 ```powershell
-Update-Module -Name Pester
+Update-Module -Name Pester -MaximumVersion 4.99
 ```
 
 ## Installing from PSGallery on other versions of Windows
@@ -66,13 +66,13 @@ In version 5 or newer you can use the built-in `Install-Module` and `Update-Modu
 From _administrator_ PowerShell command line run:
 
 ```powershell
-Install-Module -Name Pester
+Install-Module -Name Pester -MaximumVersion 4.99
 ```
 
 Or to update:
 
 ```powershell
-Update-Module -Name Pester
+Update-Module -Name Pester -MaximumVersion 4.99
 ```
 
 ### PowerShell 3 and 4
@@ -82,13 +82,13 @@ for installation. See detailed [instructions here](https://docs.microsoft.com/en
 When you have the package manager installed, please start a new _administrator_ PowerShell window and use:
 
 ```powershell
-Install-Module -Name Pester
+Install-Module -Name Pester -MaximumVersion 4.99
 ```
 
 Or to update:
 
 ```powershell
-Update-Module -Name Pester
+Update-Module -Name Pester -MaximumVersion 4.99
 ```
 
 ### PowerShell 2
@@ -96,13 +96,13 @@ Update-Module -Name Pester
 On PowerShell 2 you can use an alternative to PowerShellGet called PSGet. See installation [instructions here](https://github.com/psget/psget). When you have the package manager installed, please start a new _administrator_ PowerShell window and use:
 
 ```powershell
-Install-Module -Module Pester
+Install-Module -Module Pester -MaximumVersion 4.99
 ```
 
 Or to update:
 
 ```powershell
-Update-Module -Module Pester
+Update-Module -Module Pester -MaximumVersion 4.99
 ```
 
 ## Installing from sources
@@ -136,5 +136,5 @@ choco install Pester --prerelease
 
 ### Nuget
 
-[Nuget](https://www.nuget.org/) is the package manager for .NET projects. Getting Pester from Nuget is useful when you are integrating PowerShell code with your .NET project, and want to have that code tested. To install use Package Manager of Visual Studio, or Package Manager Console in Visual Studio. Once you need this we are pretty sure you know what you are doing. :)
+[Nuget](https://www.nuget.org/) is the package manager for .NET projects. Getting Pester from Nuget is useful when you are integrating PowerShell code with your .NET project, and want to have that code tested. To install use Package Manager of Visual Studio, or Package Manager Console in Visual Studio. Once you need this we are pretty sure you know what you are doing. :slightly_smiling_face:
 

--- a/versioned_docs/version-v4/introduction/powershell-core.mdx
+++ b/versioned_docs/version-v4/introduction/powershell-core.mdx
@@ -5,20 +5,20 @@ sidebar_label: Powershell Core
 ---
 
 Since version 4.1.0 Pester is compatible with
-[PowerShell Core 6.x](https://github.com/powershell/powershell)
+[PowerShell Core 6 and later](https://github.com/powershell/powershell)
 with some limitations listed below
 
 - Pester unit tests for test a code coverage of DSC resources can't be executed
 - DSC is not supported on MacOSX
-- support on Linux [requires additional software to be installed](https://docs.microsoft.com/en-us/powershell/scripting/dsc/getting-started/lnxgettingstarted).
+- Support on Linux [requires additional software to be installed](https://docs.microsoft.com/en-us/powershell/scripting/dsc/getting-started/lnxgettingstarted).
   Please read also [DSC Future Direction Update](https://blogs.msdn.microsoft.com/powershell/2017/09/12/dsc-future-direction-update/)
   on the PowerShell Team Blog
 - An error `call depth overflow` on macOS
   ([please check](https://github.com/PowerShell/PowerShell/issues/4268))
-- the one failing test [in Pester Functions/Assertions/Be.Tests.ps1](https://github.com/pester/Pester/blob/rel/4.x.x/Functions/Assertions/Be.Tests.ps1)
+- The one failing test [in Pester Functions/Assertions/Be.Tests.ps1](https://github.com/pester/Pester/blob/rel/4.x.x/Functions/Assertions/Be.Tests.ps1)
   is disabled due that bug
 
-Please remember that not only Pester need to be aligned to work on PowerShell Core 6.x.
+Please remember that not only Pester need to be aligned to work on PowerShell Core 6.x and later.
 Also your test need to be aligned - please check the reference
 [Development rules - technical](https://github.com/pester/Pester/wiki/Development-rules---technical)
 to read more.

--- a/versioned_docs/version-v4/quick-start.mdx
+++ b/versioned_docs/version-v4/quick-start.mdx
@@ -110,7 +110,7 @@ An example of a PowerShell script to run against a single pester test file using
 
 ```powershell
 # This updates pester not always necessary but worth noting
-Install-Module -Name Pester -Force -SkipPublisherCheck
+Install-Module -Name Pester -MaximumVersion 4.99 -Force -SkipPublisherCheck
 
 Import-Module Pester
 

--- a/versioned_docs/version-v4/usage/test-results.mdx
+++ b/versioned_docs/version-v4/usage/test-results.mdx
@@ -82,7 +82,7 @@ An example of a PowerShell script to run against a single pester test file.
 
 ```powershell
 # This updates pester not always necessary but worth noting
-Install-Module -Name Pester -Force -SkipPublisherCheck
+Install-Module -Name Pester -MaximumVersion 4.99 -Force -SkipPublisherCheck
 
 Import-Module Pester
 


### PR DESCRIPTION
Pester v4 installation guide would install v5 in current state. Pinned commands to latest version for choco and `<4.99` for `Install-Module`.