### PR TITLE
Update quick-start.mdx - fix grammar typo

### DIFF
--- a/docs/quick-start.mdx
+++ b/docs/quick-start.mdx
@@ -95,7 +95,7 @@ Tests completed in 179ms
 Tests Passed: 1, Failed: 0, Skipped: 0 NotRun: 0
 ```
 
-Looking at the last line of output you can see that we run 1 test and it Passed. Good job, you just run your first Pester test! 🥳🥳🥳
+Looking at the last line of output you can see that we ran 1 test and it Passed. Good job, you just ran your first Pester test! 🥳🥳🥳
 
 ### Understanding our test
 


### PR DESCRIPTION
Edited 2 instances of 'run' to 'ran' since it is being used in a past tense.