### PR TITLE
Suggest correction to docs for displaying Pester coverage in TeamCity

### DIFF
--- a/docs/usage/test-results.mdx
+++ b/docs/usage/test-results.mdx
@@ -55,8 +55,8 @@ Code coverage metrics are not included in the NUnit xml report so it is necessar
 
 ```powershell
 $testResults = Invoke-Pester -OutputFile Test.xml -OutputFormat NUnitXml -CodeCoverage (Get-ChildItem -Path $PSScriptRoot\*.ps1 -Exclude *.Tests.* ).FullName -PassThru
-Write-Output "##teamcity[buildStatisticValue key='CodeCoverageAbsLTotal' value='$($testResults.CodeCoverage.NumberOfCommandsAnalyzed)']"
-Write-Output "##teamcity[buildStatisticValue key='CodeCoverageAbsLCovered' value='$($testResults.CodeCoverage.NumberOfCommandsExecuted)']"
+Write-Output "##teamcity[buildStatisticValue key='CodeCoverageAbsLTotal' value='$($testResults.CodeCoverage.CommandsAnalyzedCount)']"
+Write-Output "##teamcity[buildStatisticValue key='CodeCoverageAbsLCovered' value='$($testResults.CodeCoverage.CommandsExecutedCount)']"
 ```
 
 ## [AppVeyor](https://appveyor.com)


### PR DESCRIPTION
The currently documented properties  
NumberOfCommandsAnalyzed 
and 
NumberOfCommandsExecuted 

appear to actually need to be 
CommandsAnalyzedCount
and 
CommandsExecutedCount

At least in current versions.  This may have been right once, but now throws an error using latest Pester and a fairly recent TeamCity installation.