### PR TITLE
Use PowerShell 7.3 for docs PR workflow

### DIFF
--- a/.github/workflows/generate-pester-docs.yml
+++ b/.github/workflows/generate-pester-docs.yml
@@ -37,8 +37,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-        # Temporary workaround for pending platyPS fix for https://github.com/PowerShell/platyPS/issues/663
-        # PowerShell 7.4+ in images add -ProgressAction to help
+      # TEMP workaround for https://github.com/PowerShell/platyPS/issues/663 affection PS 7.4+ used in runner images
       - name: Downgrade to PowerShell 7.3
         shell: pwsh
         run: |
@@ -47,6 +46,7 @@ jobs:
           sudo dpkg -i packages-microsoft-prod.deb
           sudo apt-get update
           sudo apt-get install -y powershell=7.3.11-1.deb
+          rm packages-microsoft-prod.deb
           pwsh --version
 
       # This step will also install and import modules incl. selected Pester-version

--- a/.github/workflows/generate-pester-docs.yml
+++ b/.github/workflows/generate-pester-docs.yml
@@ -37,6 +37,18 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+        # Temporary workaround for pending platyPS fix for https://github.com/PowerShell/platyPS/issues/663
+        # PowerShell 7.4+ in images add -ProgressAction to help
+      - name: Downgrade to PowerShell 7.3
+        shell: pwsh
+        run: |
+          sudo apt-get remove powershell
+          curl https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb -o packages-microsoft-prod.deb
+          sudo dpkg -i packages-microsoft-prod.deb
+          sudo apt-get update
+          sudo apt-get install -y powershell=7.3.11-1.deb
+          pwsh --version
+
       # This step will also install and import modules incl. selected Pester-version
       - name: Update Command Reference
         id: commands


### PR DESCRIPTION
platyPS currently adds `-ProgressAction` common parameter to all docs. Downgrading workflow to PS 7.3 until https://github.com/PowerShell/platyPS/issues/663 is fixed