### PR TITLE
Pin generate-pester-docs.yml to Ubuntu 22.04

### DIFF
--- a/.github/workflows/generate-pester-docs.yml
+++ b/.github/workflows/generate-pester-docs.yml
@@ -21,7 +21,7 @@ on:
 jobs:
   generate_docs:
     name: Docs PR
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       PESTER: ${{ github.event.inputs.pester_version }}
       DOCS: ${{ github.event.inputs.docs_version }}


### PR DESCRIPTION
PowerShell 7.3 doesn't install on Ubuntu 24.04 due to libicu72 missing because libicu74 is built-in. Pinning 22.04 image for now.