### PR TITLE
Missing comma in scriptblock for v6.

### DIFF
--- a/docs/usage/mocking.mdx
+++ b/docs/usage/mocking.mdx
@@ -109,7 +109,7 @@ function Invoke-PesterJob {
     param(
         [Parameter(Position=0)]
         [string[]] $Path = '.',
-        [string[]] $ExcludePath = @()
+        [string[]] $ExcludePath = @(),
         [string[]] $TagFilter,
         [string[]] $ExcludeTagFilter,
         [string[]] $FullNameFilter,


### PR DESCRIPTION
Missing comma in scriptblock mocking.mdx for v6 docs.