### PR TITLE
ADDING mocking script for pesterV5 DOCS

### DIFF
--- a/versioned_docs/version-v5/usage/mocking.mdx
+++ b/versioned_docs/version-v5/usage/mocking.mdx
@@ -155,12 +155,11 @@ Describe 'Mocking native commands' {
 
 ### Mocking function in scriptblock
 
-    unfortunately we don't have straightforward to mocking a function inside a scriptblock
-but we could use some workaround to accomplish
+Unfortunately, we don't have a straightforward way to mock a function inside a scriptblock, but we could use some workarounds to accomplish this.
 
 ```
 ---t1.ps1---
-
+# base https://github.com/pester/Pester/issues/1069
 ###  --- file t1.ps1
 param (
     [Parameter(Mandatory)]
@@ -202,6 +201,8 @@ Main -Name $Name
 
 ```
 --t1.test.ps1--
+
+
 BeforeAll{
 
     Add-Type -TypeDefinition @'
@@ -282,7 +283,23 @@ Describe "t1.ps1" {
 -----------
 ```
 
-    The following could mock the function inside script with parameter and entry point
+```
+/Users/nohwnd/Desktop/t1.ps1
+Hello, Thomas!
+Hello, Thomas!
+this is placeholder
+
+Describing t1.ps1
+/Users/nohwnd/Desktop/t1.ps1
+Hello, Pester!
+  [+] Can test 'Main' function 58ms
+Hello, Pester!
+  [+] Can test 'Get-Greeting' function 34ms
+Pester is getting better at mocking!
+  [+] Can mock Get-GreetingText that is used by Get-GreetingFunction 65ms
+```
+One small problem with this, if you encapsulate the steps into a helper function (say Import-Script) then you will dot-source into the scope of Import-Script and your functions won't be available for testing. I will test this using iex, and if that works, then I can encapsulate it in binary cmdlet, that does when iex does + the extra aliasing behavior.
+
 
 
 
@@ -407,4 +424,3 @@ Describe "d" {
         Should -Invoke f -Exactly 0
     }
 }
-```

--- a/versioned_docs/version-v5/usage/mocking.mdx
+++ b/versioned_docs/version-v5/usage/mocking.mdx
@@ -154,8 +154,11 @@ Describe 'Mocking native commands' {
 ```
 
 ### Mocking function in scriptblock
-
 Unfortunately, we don't have a straightforward way to mock a function inside a scriptblock, but we could use some workarounds to accomplish this.
+
+warning：Mocking may not work correctly in Pester versions below v5, so this function is only supported in Pester v5. In earlier versions, you cannot run the mock together with the script.
+
+
 
 ```
 ---t1.ps1---
@@ -202,6 +205,8 @@ Main -Name $Name
 ```
 --t1.test.ps1--
 
+
+#warning :Mocking may not work correctly in Pester versions below v5, so this function is only supported in Pester v5. In earlier versions, you cannot run the mock together with the script.
 
 BeforeAll{
 
@@ -263,8 +268,9 @@ namespace ScriptMocking
   Import-Module ([ScriptMocking.ImportScriptCommand].Assembly)
 Import-Script -Path "$psScriptRoot/t1.ps1" -EntryPoint 'Main' -ArgumentList '-Name Jakub'
 
-}
 
+}
+Describe 'test scriptMocking'{
  
 Describe "t1.ps1" {
     It "Can test 'Main' function" {
@@ -280,25 +286,17 @@ Describe "t1.ps1" {
         Get-Greeting -Name 'Pester' | Should -Be 'Pester is getting better at mocking!'
     }
 }
------------
-```
-
-```
-/Users/nohwnd/Desktop/t1.ps1
-Hello, Thomas!
-Hello, Thomas!
-this is placeholder
-
-Describing t1.ps1
-/Users/nohwnd/Desktop/t1.ps1
+}
+<#
+output :
 Hello, Pester!
-  [+] Can test 'Main' function 58ms
 Hello, Pester!
-  [+] Can test 'Get-Greeting' function 34ms
 Pester is getting better at mocking!
-  [+] Can mock Get-GreetingText that is used by Get-GreetingFunction 65ms
-```
-One small problem with this, if you encapsulate the steps into a helper function (say Import-Script) then you will dot-source into the scope of Import-Script and your functions won't be available for testing. I will test this using iex, and if that works, then I can encapsulate it in binary cmdlet, that does when iex does + the extra aliasing behavior.
+[+] O:\OneDrive\script-tester\mockFunction.test.ps1 363ms (119ms|202ms)
+Tests completed in 370ms
+Tests Passed: 3, Failed: 0, Skipped: 0, Inconclusive: 0, NotRun: 0
+PS C:\Users\Administrator> Remove-Module -name pester -Force     
+#>
 
 
 

--- a/versioned_docs/version-v5/usage/mocking.mdx
+++ b/versioned_docs/version-v5/usage/mocking.mdx
@@ -301,7 +301,7 @@ PS C:\Users\Administrator> Remove-Module -name pester -Force
 
 
 
-
+```
 
 ## $PesterBoundParameters
 

--- a/versioned_docs/version-v5/usage/mocking.mdx
+++ b/versioned_docs/version-v5/usage/mocking.mdx
@@ -153,6 +153,141 @@ Describe 'Mocking native commands' {
 }
 ```
 
+### Mocking function in scriptblock
+
+    unfortunately we don't have straightforward to mocking a function inside a scriptblock
+but we could use some workaround to accomplish
+
+```
+---t1.ps1---
+
+###  --- file t1.ps1
+param (
+    [Parameter(Mandatory)]
+    $Name
+)
+
+# our entry point function that holds 
+# all the stuff that should happen when 
+# we run this script
+function Main {
+    param (
+        [Parameter(Mandatory)]
+        $Name
+    )
+    Write-Host $PSCommandPath
+    Get-Greeting $Name
+}
+
+# internal function that writes greeting
+function Get-Greeting {
+    param ($Name) 
+
+    $text = Get-GreetingText 
+    $formattedGreetingText = $text -f $Name
+    Write-Host $formattedGreetingText
+    $formattedGreetingText
+}
+
+# another internal function that collaborates
+# with Get-Greeting and that we will mock 
+# in our tests
+function Get-GreetingText {
+    'Hello, {0}!'
+}
+
+Main -Name $Name
+---------------
+```
+
+```
+--t1.test.ps1--
+BeforeAll{
+
+    Add-Type -TypeDefinition @'
+using System.Collections.ObjectModel;
+using System.Management.Automation;
+using System.Reflection;
+
+namespace ScriptMocking
+{
+    [Cmdlet(VerbsData.Import, "Script")]
+    public sealed class ImportScriptCommand : PSCmdlet
+    {
+        private static string Body = @"
+            function ____placeholder {{ }}
+            # alias to prevent main from running
+            Set-Alias {0} '____placeholder'
+            
+            . {1} {2}
+            # remove the alias, now we have all functions
+            # from the script dot-sourced in this scope
+            Remove-Item 'alias:{0}' -Force
+            Remove-Item 'function:____placeholder' -Force";
+
+        [Parameter(Position = 0, Mandatory = true)]
+        public string Path { get; set; }
+
+        [Parameter(Position = 1)]
+        public string EntryPoint { get; set; }
+
+        [Parameter]
+        public string[] ArgumentList { get; set; }
+
+        public ImportScriptCommand() {
+            ArgumentList = new string[0];
+            EntryPoint = "Main";
+        }
+        protected override void ProcessRecord()
+        {
+            var body =  string.Format(Body, EntryPoint, Path, string.Join(" ", ArgumentList));
+
+            var sb = InvokeCommand.NewScriptBlock(body);
+
+            var method = sb.GetType()
+                .GetMethod("InvokeUsingCmdlet", BindingFlags.Instance | BindingFlags.NonPublic);
+
+            var emptyArray = new object[0];
+            var automationNull = new PSObject();
+            const int writeToCurrentErrorPipe = 1;
+
+            var @params = new object[]
+                {this, false, writeToCurrentErrorPipe, automationNull, emptyArray, automationNull, new object[0]};
+
+            method.Invoke(sb, @params);
+        }
+    }
+}
+'@
+  Import-Module ([ScriptMocking.ImportScriptCommand].Assembly)
+Import-Script -Path "$psScriptRoot/t1.ps1" -EntryPoint 'Main' -ArgumentList '-Name Jakub'
+
+}
+
+ 
+Describe "t1.ps1" {
+    It "Can test 'Main' function" {
+        Main -Name 'Pester' | Should -Be 'Hello, Pester!'
+    }
+
+    It "Can test 'Get-Greeting' function" {
+        Get-Greeting -Name 'Pester' | Should -Be 'Hello, Pester!'
+    }
+
+    It "Can mock Get-GreetingText that is used by Get-GreetingFunction" {
+        Mock Get-GreetingText { '{0} is getting better at mocking!'  }
+        Get-Greeting -Name 'Pester' | Should -Be 'Pester is getting better at mocking!'
+    }
+}
+-----------
+```
+
+    The following could mock the function inside script with parameter and entry point
+
+
+
+
+
 ## $PesterBoundParameters
 
 Calling a mocked command will execute a proxy-function (hook) which evaluates and chooses the correct behavior/mock to invoke in that scenario. Because of this proxy `$PSBoundParameters` will be overwritten and are not available inside your mock's scriptblock.


### PR DESCRIPTION
i read about the [issue](https://github.com/pester/Pester/issues/1069)

And test the function,it work fine in pesterV5 but fail in V4,it is a good assertion ,hoping to add the in scriptscope in modules future