### PR TITLE
Document new v6 Should-* assertions

### DIFF
--- a/docs/assertions/should-command.mdx
+++ b/docs/assertions/should-command.mdx
@@ -65,11 +65,11 @@ Another special case is `@()`. A value assertion will handle it as `$null`, but 
 1 | Should-Be -Expected 1
 @(1) | Should-Be -Expected 1
 $null | Should-Be -Expected $null
-@() | Should-Be -Expected $null #< --- TODO: this is not the case right now, we special case this as empty array, but is that correct? it does not play well with the value and collection assertion, and we special case it just because we can.
-# $null | will give $local:input -> $null , and @() | will give $local:input -> @(), is that distinction important when we know that we will only check against values?
+@() | Should-Be -Expected $null # @() is handled as $null by a value assertion
 
 # This fails, because -Expected does not allow collections.
 @() | Should-Be -Expected @()
+```
 
 ```powershell
 # Should-BeCollection is a collection assertion:
@@ -121,7 +121,121 @@ These assertions take the advantage of being more specialized to provide a type 
 
 ### Collection assertions
 
-<mark>TODO</mark>
+Collection assertions operate on the whole collection provided to `$Actual` instead of unwrapping it to a single value. Use them whenever you want to assert on multiple items at once.
+
+#### Generic collection assertions
+
+[`Should-BeCollection`](../commands/Should-BeCollection.mdx) compares two collections by first comparing their size, and then comparing each item. The `$Expected` value must be a collection.
+
+```powershell
+1, 2, 3 | Should-BeCollection @(1, 2, 3)
+@(1)    | Should-BeCollection @(1)
+
+# This fails, the collections have different sizes.
+1, 2, 3, 4 | Should-BeCollection @(1, 2, 3)
+```
+
+You can also assert on the size of a collection without comparing items, by using `-Count`:
+
+```powershell
+1, 2, 3 | Should-BeCollection -Count 3
+```
+
+[`Should-ContainCollection`](../commands/Should-ContainCollection.mdx) and [`Should-NotContainCollection`](../commands/Should-NotContainCollection.mdx) check whether the expected items are (or are not) present in the provided collection, in order.
+
+```powershell
+1, 2, 3 | Should-ContainCollection @(1, 2)
+1, 2, 3 | Should-NotContainCollection @(3, 4)
+```
+
+#### Combinator assertions
+
+Combinator assertions take a `-FilterScript` and run it against every item in the collection. The filter can be a plain PowerShell expression or another `Should-*` assertion.
+
+[`Should-All`](../commands/Should-All.mdx) passes when **every** item matches the filter:
+
+```powershell
+1, 2, 3 | Should-All { $_ -gt 0 }
+1, 2, 3 | Should-All { $_ | Should-BeGreaterThan 0 }
+```
+
+[`Should-Any`](../commands/Should-Any.mdx) passes when **at least one** item matches the filter:
+
+```powershell
+1, 2, 3 | Should-Any { $_ -gt 2 }
+1, 2, 3 | Should-Any { $_ | Should-BeGreaterThan 2 }
+```
+
+### Assertion reference
+
+All `Should-*` assertions are listed below, grouped by the kind of check they perform. Follow a link to see the full syntax, parameters, and examples in the Command Reference.
+
+#### General
+
+- [`Should-Be`](../commands/Should-Be.mdx) — Compares the expected value to the actual value to see if they are equal.
+- [`Should-NotBe`](../commands/Should-NotBe.mdx) — Compares the expected value to the actual value to see if they are not equal.
+- [`Should-BeGreaterThan`](../commands/Should-BeGreaterThan.mdx) — Asserts that the actual value is greater than the expected value.
+- [`Should-BeGreaterThanOrEqual`](../commands/Should-BeGreaterThanOrEqual.mdx) — Asserts that the actual value is greater than or equal to the expected value.
+- [`Should-BeLessThan`](../commands/Should-BeLessThan.mdx) — Asserts that the actual value is less than the expected value.
+- [`Should-BeLessThanOrEqual`](../commands/Should-BeLessThanOrEqual.mdx) — Asserts that the actual value is less than or equal to the expected value.
+- [`Should-BeNull`](../commands/Should-BeNull.mdx) — Asserts that the input is `$null`.
+- [`Should-NotBeNull`](../commands/Should-NotBeNull.mdx) — Asserts that the input is not `$null`.
+- [`Should-BeSame`](../commands/Should-BeSame.mdx) — Asserts that the actual value is the same instance as the expected value.
+- [`Should-NotBeSame`](../commands/Should-NotBeSame.mdx) — Asserts that the actual value is not the same instance as the expected value.
+- [`Should-HaveType`](../commands/Should-HaveType.mdx) — Asserts that the input is of the expected type.
+- [`Should-NotHaveType`](../commands/Should-NotHaveType.mdx) — Asserts that the input is not of the expected type.
+
+#### Boolean
+
+- [`Should-BeTrue`](../commands/Should-BeTrue.mdx) — Asserts that the actual value is `$true`.
+- [`Should-BeFalse`](../commands/Should-BeFalse.mdx) — Asserts that the actual value is `$false`.
+- [`Should-BeTruthy`](../commands/Should-BeTruthy.mdx) — Asserts that the actual value is truthy.
+- [`Should-BeFalsy`](../commands/Should-BeFalsy.mdx) — Asserts that the actual value is falsy (`0`, `""`, `$null` or `@()`).
+
+#### String
+
+- [`Should-BeString`](../commands/Should-BeString.mdx) — Asserts that the actual value is equal to the expected string. Supports `-CaseSensitive`, `-IgnoreWhitespace` and `-TrimWhitespace`.
+- [`Should-NotBeString`](../commands/Should-NotBeString.mdx) — Asserts that the actual value is not equal to the expected string.
+- [`Should-BeEmptyString`](../commands/Should-BeEmptyString.mdx) — Asserts that the input is an empty string.
+- [`Should-NotBeEmptyString`](../commands/Should-NotBeEmptyString.mdx) — Asserts that the input is a string that is not `$null` or empty.
+- [`Should-NotBeWhiteSpaceString`](../commands/Should-NotBeWhiteSpaceString.mdx) — Asserts that the input is a string that is not `$null`, empty, or whitespace only.
+- [`Should-BeLikeString`](../commands/Should-BeLikeString.mdx) — Asserts that the actual value matches the expected wildcard pattern.
+- [`Should-NotBeLikeString`](../commands/Should-NotBeLikeString.mdx) — Asserts that the actual value does not match the expected wildcard pattern.
+- [`Should-MatchString`](../commands/Should-MatchString.mdx) — Asserts that the actual value matches the expected regular expression.
+- [`Should-NotMatchString`](../commands/Should-NotMatchString.mdx) — Asserts that the actual value does not match the expected regular expression.
+
+#### Collection
+
+- [`Should-BeCollection`](../commands/Should-BeCollection.mdx) — Compares collections for equality, by comparing their size and each item.
+- [`Should-ContainCollection`](../commands/Should-ContainCollection.mdx) — Asserts that the expected items are present in the provided collection, in order.
+- [`Should-NotContainCollection`](../commands/Should-NotContainCollection.mdx) — Asserts that the expected items are not present in the provided collection.
+- [`Should-All`](../commands/Should-All.mdx) — Asserts that every item in the collection matches a filter.
+- [`Should-Any`](../commands/Should-Any.mdx) — Asserts that at least one item in the collection matches a filter.
+
+#### Equivalency
+
+- [`Should-BeEquivalent`](../commands/Should-BeEquivalent.mdx) — Recursively compares two objects for equivalency, by comparing their properties.
+
+#### DateTime and TimeSpan
+
+- [`Should-BeBefore`](../commands/Should-BeBefore.mdx) — Asserts that the actual `[datetime]` is before the expected `[datetime]`.
+- [`Should-BeAfter`](../commands/Should-BeAfter.mdx) — Asserts that the actual `[datetime]` is after the expected `[datetime]`.
+- [`Should-BeFasterThan`](../commands/Should-BeFasterThan.mdx) — Asserts that the provided `[timespan]` or `[scriptblock]` is faster than the expected `[timespan]`.
+- [`Should-BeSlowerThan`](../commands/Should-BeSlowerThan.mdx) — Asserts that the provided `[timespan]` or `[scriptblock]` is slower than the expected `[timespan]`.
+
+#### Exception
+
+- [`Should-Throw`](../commands/Should-Throw.mdx) — Asserts that a script block throws an exception.
+
+#### Mock
+
+- [`Should-Invoke`](../commands/Should-Invoke.mdx) — Asserts that a mocked command was called the expected number of times. See [Mocking](../usage/mocking).
+- [`Should-NotInvoke`](../commands/Should-NotInvoke.mdx) — Asserts that a mocked command was not called. See [Mocking](../usage/mocking).
+
+#### Command parameters
+
+- [`Should-HaveParameter`](../commands/Should-HaveParameter.mdx) — Asserts that a command has the expected parameter, and optionally checks its type, default value, aliases, parameter set, mandatory status, and argument completer.
+- [`Should-NotHaveParameter`](../commands/Should-NotHaveParameter.mdx) — Asserts that a command does not have the given parameter.
 
 ## `Should` (v4/v5)
 

--- a/docs/commands/Should-HaveParameter.mdx
+++ b/docs/commands/Should-HaveParameter.mdx
@@ -1,0 +1,223 @@
+---
+id: Should-HaveParameter
+title: Should-HaveParameter
+description: Help page for the PowerShell Pester "Should-HaveParameter" command
+keywords:
+  - PowerShell
+  - Pester
+  - Help
+  - Documentation
+hide_title: false
+hide_table_of_contents: false
+custom_edit_url: null
+---
+
+:::info This page was generated
+Contributions are welcome in [Pester-repo](https://github.com/pester/pester).
+:::
+
+## SYNOPSIS
+
+Asserts that a command has the expected parameter.
+
+## SYNTAX
+
+```powershell
+Should-HaveParameter [[-ParameterName] <String>] [[-Type] <Object>] [[-DefaultValue] <String>] [-Mandatory]
+ [[-InParameterSet] <String>] [-HasArgumentCompleter] [[-Alias] <String[]>] [[-Actual] <Object>]
+ [[-Because] <String>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+This assertion inspects command metadata and can also verify parameter details such as type, default value, aliases, parameter set membership, mandatory status, and argument completers.
+
+## EXAMPLES
+
+### EXAMPLE 1
+
+```powershell
+Get-Command "Invoke-WebRequest" | Should -HaveParameter Uri -Mandatory
+```
+
+This test passes, because it expected the parameter URI to exist and to
+be mandatory.
+
+## PARAMETERS
+
+### -ParameterName
+
+The name of the parameter to check.
+E.g.
+Uri
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Type
+
+The type of the parameter to check.
+E.g.
+[string]
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DefaultValue
+
+The default value of the parameter to check.
+E.g.
+"https://example.com"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Mandatory
+
+Whether the parameter is mandatory or not.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -InParameterSet
+
+The parameter set that the parameter belongs to.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -HasArgumentCompleter
+
+Whether the parameter has an argument completer or not.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Alias
+
+The alias of the parameter to check.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 5
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Actual
+
+The actual command to check.
+E.g.
+Get-Command "Invoke-WebRequest"
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 6
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -Because
+
+The reason why the input should be the expected value.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 7
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+The attribute [ArgumentCompleter] was added with PSv5.
+Previously this
+assertion will not be able to use the -HasArgumentCompleter parameter
+if the attribute does not exist.
+
+## RELATED LINKS
+
+[https://pester.dev/docs/commands/Should-HaveParameter](https://pester.dev/docs/commands/Should-HaveParameter)
+
+[https://pester.dev/docs/assertions](https://pester.dev/docs/assertions)
+
+## VERSION
+
+*This page was generated using comment-based help in [Pester 6.0.0-alpha5](https://github.com/pester/pester).*

--- a/docs/commands/Should-Invoke.mdx
+++ b/docs/commands/Should-Invoke.mdx
@@ -1,0 +1,366 @@
+---
+id: Should-Invoke
+title: Should-Invoke
+description: Help page for the PowerShell Pester "Should-Invoke" command
+keywords:
+  - PowerShell
+  - Pester
+  - Help
+  - Documentation
+hide_title: false
+hide_table_of_contents: false
+custom_edit_url: null
+---
+
+:::info This page was generated
+Contributions are welcome in [Pester-repo](https://github.com/pester/pester).
+:::
+
+## SYNOPSIS
+
+Checks if a Mocked command has been called a certain number of times
+and throws an exception if it has not.
+
+## SYNTAX
+
+### Default (Default)
+
+```powershell
+Should-Invoke [-CommandName] <String> [[-Times] <Int32>] [-ParameterFilter <ScriptBlock>]
+ [-ExclusiveFilter <ScriptBlock>] [-ModuleName <String>] [-Scope <String>] [-Exactly] [-Because <String>]
+ [<CommonParameters>]
+```
+
+### ExclusiveFilter
+
+```powershell
+Should-Invoke -ExclusiveFilter <ScriptBlock> [<CommonParameters>]
+```
+
+### Verifiable
+
+```powershell
+Should-Invoke [-Because <String>] [-Verifiable] [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+This command verifies that a mocked command has been called a certain number
+of times. 
+If the call history of the mocked command does not match the parameters
+passed to Should-Invoke, Should-Invoke will throw an exception.
+
+## EXAMPLES
+
+### EXAMPLE 1
+
+```powershell
+Mock Set-Content {}
+
+{...
+Some Code ...}
+
+Should-Invoke Set-Content
+```
+
+This will throw an exception and cause the test to fail if Set-Content is not called in Some Code.
+
+### EXAMPLE 2
+
+```powershell
+Mock Set-Content -parameterFilter {$path.StartsWith("$env:temp\")}
+
+{...
+Some Code ...}
+
+Should-Invoke Set-Content 2 { $path -eq "$env:temp\test.txt" }
+```
+
+This will throw an exception if some code calls Set-Content on $path=$env:temp\test.txt less than 2 times
+
+### EXAMPLE 3
+
+```powershell
+Mock Set-Content {}
+
+{...
+Some Code ...}
+
+Should-Invoke Set-Content 0
+```
+
+This will throw an exception if some code calls Set-Content at all
+
+### EXAMPLE 4
+
+```powershell
+Mock Set-Content {}
+```
+
+\{...
+Some Code ...\}
+
+Should-Invoke Set-Content -Exactly 2
+
+This will throw an exception if some code does not call Set-Content Exactly two times.
+
+### EXAMPLE 5
+
+```powershell
+Describe 'Should-Invoke Scope behavior' {
+    Mock Set-Content { }
+
+    It 'Calls Set-Content at least once in the It block' {
+        {...
+Some Code ...}
+
+        Should-Invoke Set-Content -Exactly 0 -Scope It
+    }
+}
+```
+
+Checks for calls only within the current It block.
+
+### EXAMPLE 6
+
+```powershell
+Describe 'Describe' {
+    Mock -ModuleName SomeModule Set-Content { }
+
+{...
+Some Code ...}
+
+    It 'Calls Set-Content at least once in the Describe block' {
+        Should-Invoke -ModuleName SomeModule Set-Content
+    }
+}
+```
+
+Checks for calls to the mock within the SomeModule module. 
+Note that both the Mock
+and Should-Invoke commands use the same module name.
+
+### EXAMPLE 7
+
+```powershell
+Should-Invoke Get-ChildItem -ExclusiveFilter { $Path -eq 'C:\' }
+```
+
+Checks to make sure that Get-ChildItem was called at least one time with
+the -Path parameter set to 'C:\', and that it was not called at all with
+the -Path parameter set to any other value.
+
+## PARAMETERS
+
+### -CommandName
+
+The mocked command whose call history should be checked.
+
+```yaml
+Type: String
+Parameter Sets: Default
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Times
+
+The number of times that the mock must be called to avoid an exception
+from throwing.
+
+```yaml
+Type: Int32
+Parameter Sets: Default
+Aliases:
+
+Required: False
+Position: 2
+Default value: 1
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ParameterFilter
+
+An optional filter to qualify which calls should be counted.
+Only those
+calls to the mock whose parameters cause this filter to return true
+will be counted.
+
+```yaml
+Type: ScriptBlock
+Parameter Sets: Default
+Aliases:
+
+Required: False
+Position: Named
+Default value: { $True }
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ExclusiveFilter
+
+Like ParameterFilter, except when you use ExclusiveFilter, and there
+were any calls to the mocked command which do not match the filter,
+an exception will be thrown. 
+This is a convenient way to avoid needing
+to have two calls to Should-Invoke like this:
+
+Should-Invoke SomeCommand -Times 1 -ParameterFilter \{ $something -eq $true \}
+Should-Invoke SomeCommand -Times 0 -ParameterFilter \{ $something -ne $true \}
+
+```yaml
+Type: ScriptBlock
+Parameter Sets: Default
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+```yaml
+Type: ScriptBlock
+Parameter Sets: ExclusiveFilter
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ModuleName
+
+The module where the mock being checked was injected.
+This is optional,
+and must match the ModuleName that was used when setting up the Mock.
+
+```yaml
+Type: String
+Parameter Sets: Default
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Scope
+
+An optional parameter specifying the Pester scope in which to check for
+calls to the mocked command.
+For RSpec style tests, Should-Invoke will find
+all calls to the mocked command in the current Context block (if present),
+or the current Describe block (if there is no active Context), by default.
+Valid
+values are Describe, Context and It.
+If you use a scope of Describe or
+Context, the command will identify all calls to the mocked command in the
+current Describe / Context block, as well as all child scopes of that block.
+
+```yaml
+Type: String
+Parameter Sets: Default
+Aliases:
+
+Required: False
+Position: Named
+Default value: 0
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Exactly
+
+If this switch is present, the number specified in Times must match
+exactly the number of times the mock has been called.
+Otherwise it
+must match "at least" the number of times specified. 
+If the value
+passed to the Times parameter is zero, the Exactly switch is implied.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Default
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Because
+
+The reason why the mock should be called.
+
+```yaml
+Type: String
+Parameter Sets: Default, Verifiable
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Verifiable
+
+Makes sure that all verifiable mocks were called.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Verifiable
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+The parameter filter passed to Should-Invoke does not necessarily have to match the parameter filter
+(if any) which was used to create the Mock. 
+Should-Invoke will find any entry in the command history
+which matches its parameter filter, regardless of how the Mock was created. 
+However, if any calls to the
+mocked command are made which did not match any mock's parameter filter (resulting in the original command
+being executed instead of a mock), these calls to the original command are not tracked in the call history.
+In other words, Should-Invoke can only be used to check for calls to the mocked implementation, not
+to the original.
+
+## RELATED LINKS
+
+[https://pester.dev/docs/commands/Should-Invoke](https://pester.dev/docs/commands/Should-Invoke)
+
+[https://pester.dev/docs/assertions](https://pester.dev/docs/assertions)
+
+## VERSION
+
+*This page was generated using comment-based help in [Pester 6.0.0-alpha5](https://github.com/pester/pester).*

--- a/docs/commands/Should-MatchString.mdx
+++ b/docs/commands/Should-MatchString.mdx
@@ -1,0 +1,137 @@
+---
+id: Should-MatchString
+title: Should-MatchString
+description: Help page for the PowerShell Pester "Should-MatchString" command
+keywords:
+  - PowerShell
+  - Pester
+  - Help
+  - Documentation
+hide_title: false
+hide_table_of_contents: false
+custom_edit_url: null
+---
+
+:::info This page was generated
+Contributions are welcome in [Pester-repo](https://github.com/pester/pester).
+:::
+
+## SYNOPSIS
+
+Tests whether a string matches a regular expression pattern.
+
+## SYNTAX
+
+```powershell
+Should-MatchString [[-Actual] <Object>] [-Expected] <Object> [-CaseSensitive] [-Because <String>]
+ [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+The `Should-MatchString` assertion compares the actual string to the expected regular expression pattern using the `-match` operator.
+The `-match` operator is case-insensitive by default, but you can make it case-sensitive by using the `-CaseSensitive` switch.
+
+## EXAMPLES
+
+### EXAMPLE 1
+
+```powershell
+"hello" | Should-MatchString "h.*o"
+```
+
+This assertion will pass, because the actual value matches the regular expression pattern.
+
+### EXAMPLE 2
+
+```powershell
+"hello" | Should-MatchString "H.*O" -CaseSensitive
+```
+
+This assertion will fail, because the actual value does not case-sensitively match the regular expression pattern.
+
+## PARAMETERS
+
+### -Actual
+
+The actual value.
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 2
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -Expected
+
+The expected regular expression pattern.
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -CaseSensitive
+
+Indicates that the comparison should be case-sensitive.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Because
+
+The reason why the actual value should match the regular expression pattern.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS
+
+[https://pester.dev/docs/commands/Should-MatchString](https://pester.dev/docs/commands/Should-MatchString)
+
+[https://pester.dev/docs/assertions](https://pester.dev/docs/assertions)
+
+## VERSION
+
+*This page was generated using comment-based help in [Pester 6.0.0-alpha5](https://github.com/pester/pester).*

--- a/docs/commands/Should-NotHaveParameter.mdx
+++ b/docs/commands/Should-NotHaveParameter.mdx
@@ -1,0 +1,122 @@
+---
+id: Should-NotHaveParameter
+title: Should-NotHaveParameter
+description: Help page for the PowerShell Pester "Should-NotHaveParameter" command
+keywords:
+  - PowerShell
+  - Pester
+  - Help
+  - Documentation
+hide_title: false
+hide_table_of_contents: false
+custom_edit_url: null
+---
+
+:::info This page was generated
+Contributions are welcome in [Pester-repo](https://github.com/pester/pester).
+:::
+
+## SYNOPSIS
+
+Asserts that a command has does not have the parameter.
+
+## SYNTAX
+
+```powershell
+Should-NotHaveParameter [[-ParameterName] <String>] [[-Actual] <Object>] [[-Because] <String>]
+ [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+This assertion inspects command metadata to verify that a parameter is absent.
+It only checks the parameter name, unlike `Should-HaveParameter`, which can also validate parameter details.
+
+## EXAMPLES
+
+### EXAMPLE 1
+
+```powershell
+Get-Command "Invoke-WebRequest" | Should -NotHaveParameter Uri
+```
+
+This test fails, because it expected the parameter URI to not exist.
+
+## PARAMETERS
+
+### -ParameterName
+
+The name of the parameter to check.
+E.g.
+Uri
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Actual
+
+The actual command to check.
+E.g.
+Get-Command "Invoke-WebRequest"
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 2
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -Because
+
+The reason why the input should be the expected value.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 3
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+The attribute [ArgumentCompleter] was added with PSv5.
+Previously this
+assertion will not be able to use the -HasArgumentCompleter parameter
+if the attribute does not exist.
+
+## RELATED LINKS
+
+[https://pester.dev/docs/commands/Should-NotHaveParameter](https://pester.dev/docs/commands/Should-NotHaveParameter)
+
+[https://pester.dev/docs/assertions](https://pester.dev/docs/assertions)
+
+## VERSION
+
+*This page was generated using comment-based help in [Pester 6.0.0-alpha5](https://github.com/pester/pester).*

--- a/docs/commands/Should-NotInvoke.mdx
+++ b/docs/commands/Should-NotInvoke.mdx
@@ -1,0 +1,365 @@
+---
+id: Should-NotInvoke
+title: Should-NotInvoke
+description: Help page for the PowerShell Pester "Should-NotInvoke" command
+keywords:
+  - PowerShell
+  - Pester
+  - Help
+  - Documentation
+hide_title: false
+hide_table_of_contents: false
+custom_edit_url: null
+---
+
+:::info This page was generated
+Contributions are welcome in [Pester-repo](https://github.com/pester/pester).
+:::
+
+## SYNOPSIS
+
+Checks that mocked command was not called and throws exception if it was.
+
+## SYNTAX
+
+### Default (Default)
+
+```powershell
+Should-NotInvoke [-CommandName] <String> [[-Times] <Int32>] [-ParameterFilter <ScriptBlock>]
+ [-ExclusiveFilter <ScriptBlock>] [-ModuleName <String>] [-Scope <String>] [-Exactly] [-Because <String>]
+ [<CommonParameters>]
+```
+
+### ExclusiveFilter
+
+```powershell
+Should-NotInvoke -ExclusiveFilter <ScriptBlock> [<CommonParameters>]
+```
+
+### Verifiable
+
+```powershell
+Should-NotInvoke [-Because <String>] [-Verifiable] [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+This command verifies that a mocked command has not been called a certain number
+of times. 
+If the call history of the mocked command does not match the parameters
+passed to Should-NotInvoke, Should-NotInvoke will throw an exception.
+
+## EXAMPLES
+
+### EXAMPLE 1
+
+```powershell
+Mock Set-Content {}
+```
+
+\{...
+Some Code ...\}
+
+Should-NotInvoke Set-Content
+
+This will throw an exception and cause the test to fail if Set-Content is not called in Some Code.
+
+### EXAMPLE 2
+
+```powershell
+Mock Set-Content -parameterFilter {$path.StartsWith("$env:temp\")}
+```
+
+\{...
+Some Code ...\}
+
+Should-NotInvoke Set-Content 2 \{ $path -eq "$env:temp\test.txt" \}
+
+This will throw an exception if some code calls Set-Content on $path=$env:temp\test.txt less than 2 times
+
+### EXAMPLE 3
+
+```powershell
+Mock Set-Content {}
+```
+
+\{...
+Some Code ...\}
+
+Should-NotInvoke Set-Content 0
+
+This will throw an exception if some code calls Set-Content at all
+
+### EXAMPLE 4
+
+```powershell
+Mock Set-Content {}
+```
+
+\{...
+Some Code ...\}
+
+Should-NotInvoke Set-Content -Exactly 2
+
+This will throw an exception if some code does not call Set-Content Exactly two times.
+
+### EXAMPLE 5
+
+```powershell
+Describe 'Should-NotInvoke Scope behavior' {
+    Mock Set-Content { }
+```
+
+    It 'Calls Set-Content at least once in the It block' \{
+        \{...
+Some Code ...\}
+
+        Should-NotInvoke Set-Content -Exactly 0 -Scope It
+    \}
+\}
+
+Checks for calls only within the current It block.
+
+### EXAMPLE 6
+
+```powershell
+Describe 'Describe' {
+    Mock -ModuleName SomeModule Set-Content { }
+```
+
+\{...
+Some Code ...\}
+
+    It 'Calls Set-Content at least once in the Describe block' \{
+        Should-NotInvoke -ModuleName SomeModule Set-Content
+    \}
+\}
+
+Checks for calls to the mock within the SomeModule module. 
+Note that both the Mock
+and Should-NotInvoke commands use the same module name.
+
+### EXAMPLE 7
+
+```powershell
+Should-NotInvoke Get-ChildItem -ExclusiveFilter { $Path -eq 'C:\' }
+```
+
+Checks to make sure that Get-ChildItem was called at least one time with
+the -Path parameter set to 'C:\', and that it was not called at all with
+the -Path parameter set to any other value.
+
+## PARAMETERS
+
+### -CommandName
+
+The mocked command whose call history should be checked.
+
+```yaml
+Type: String
+Parameter Sets: Default
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Times
+
+The number of times that the mock must be called to avoid an exception
+from throwing.
+
+```yaml
+Type: Int32
+Parameter Sets: Default
+Aliases:
+
+Required: False
+Position: 2
+Default value: 1
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ParameterFilter
+
+An optional filter to qualify which calls should be counted.
+Only those
+calls to the mock whose parameters cause this filter to return true
+will be counted.
+
+```yaml
+Type: ScriptBlock
+Parameter Sets: Default
+Aliases:
+
+Required: False
+Position: Named
+Default value: { $True }
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ExclusiveFilter
+
+Like ParameterFilter, except when you use ExclusiveFilter, and there
+were any calls to the mocked command which do not match the filter,
+an exception will be thrown. 
+This is a convenient way to avoid needing
+to have two calls to Should-NotInvoke like this:
+
+Should-NotInvoke SomeCommand -Times 1 -ParameterFilter \{ $something -eq $true \}
+Should-NotInvoke SomeCommand -Times 0 -ParameterFilter \{ $something -ne $true \}
+
+```yaml
+Type: ScriptBlock
+Parameter Sets: Default
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+```yaml
+Type: ScriptBlock
+Parameter Sets: ExclusiveFilter
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ModuleName
+
+The module where the mock being checked was injected. 
+This is optional,
+and must match the ModuleName that was used when setting up the Mock.
+
+```yaml
+Type: String
+Parameter Sets: Default
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Scope
+
+An optional parameter specifying the Pester scope in which to check for
+calls to the mocked command.
+For RSpec style tests, Should-NotInvoke will find
+all calls to the mocked command in the current Context block (if present),
+or the current Describe block (if there is no active Context), by default.
+Valid
+values are Describe, Context and It.
+If you use a scope of Describe or
+Context, the command will identify all calls to the mocked command in the
+current Describe / Context block, as well as all child scopes of that block.
+
+```yaml
+Type: String
+Parameter Sets: Default
+Aliases:
+
+Required: False
+Position: Named
+Default value: 0
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Exactly
+
+If this switch is present, the number specified in Times must match
+exactly the number of times the mock has been called.
+Otherwise it
+must match "at least" the number of times specified. 
+If the value
+passed to the Times parameter is zero, the Exactly switch is implied.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Default
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Because
+
+The reason why the mock should be called.
+
+```yaml
+Type: String
+Parameter Sets: Default, Verifiable
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Verifiable
+
+Makes sure that all verifiable mocks were called.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Verifiable
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+The parameter filter passed to Should-NotInvoke does not necessarily have to match the parameter filter
+(if any) which was used to create the Mock. 
+Should-NotInvoke will find any entry in the command history
+which matches its parameter filter, regardless of how the Mock was created. 
+However, if any calls to the
+mocked command are made which did not match any mock's parameter filter (resulting in the original command
+being executed instead of a mock), these calls to the original command are not tracked in the call history.
+In other words, Should-NotInvoke can only be used to check for calls to the mocked implementation, not
+to the original.
+
+## RELATED LINKS
+
+[https://pester.dev/docs/commands/Should-NotInvoke](https://pester.dev/docs/commands/Should-NotInvoke)
+
+[https://pester.dev/docs/assertions](https://pester.dev/docs/assertions)
+
+## VERSION
+
+*This page was generated using comment-based help in [Pester 6.0.0-alpha5](https://github.com/pester/pester).*

--- a/docs/commands/Should-NotMatchString.mdx
+++ b/docs/commands/Should-NotMatchString.mdx
@@ -1,0 +1,137 @@
+---
+id: Should-NotMatchString
+title: Should-NotMatchString
+description: Help page for the PowerShell Pester "Should-NotMatchString" command
+keywords:
+  - PowerShell
+  - Pester
+  - Help
+  - Documentation
+hide_title: false
+hide_table_of_contents: false
+custom_edit_url: null
+---
+
+:::info This page was generated
+Contributions are welcome in [Pester-repo](https://github.com/pester/pester).
+:::
+
+## SYNOPSIS
+
+Tests whether a string does not match a regular expression pattern.
+
+## SYNTAX
+
+```powershell
+Should-NotMatchString [[-Actual] <Object>] [-Expected] <Object> [-CaseSensitive] [-Because <String>]
+ [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+The `Should-NotMatchString` assertion compares the actual string to the expected regular expression pattern using the `-notmatch` operator.
+The `-notmatch` operator is case-insensitive by default, but you can make it case-sensitive by using the `-CaseSensitive` switch.
+
+## EXAMPLES
+
+### EXAMPLE 1
+
+```powershell
+"hello" | Should-NotMatchString "^world$"
+```
+
+This assertion will pass, because the actual value does not match the regular expression pattern.
+
+### EXAMPLE 2
+
+```powershell
+"hello" | Should-NotMatchString "h.*o" -CaseSensitive
+```
+
+This assertion will fail, because the actual value case-sensitively matches the regular expression pattern.
+
+## PARAMETERS
+
+### -Actual
+
+The actual value.
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 2
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -Expected
+
+The expected regular expression pattern.
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -CaseSensitive
+
+Indicates that the comparison should be case-sensitive.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Because
+
+The reason why the actual value should not match the regular expression pattern.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS
+
+[https://pester.dev/docs/commands/Should-NotMatchString](https://pester.dev/docs/commands/Should-NotMatchString)
+
+[https://pester.dev/docs/assertions](https://pester.dev/docs/assertions)
+
+## VERSION
+
+*This page was generated using comment-based help in [Pester 6.0.0-alpha5](https://github.com/pester/pester).*

--- a/docs/commands/docusaurus.sidebar.js
+++ b/docs/commands/docusaurus.sidebar.js
@@ -55,7 +55,10 @@ module.exports = [
     'commands/Should-BeTrue',
     'commands/Should-BeTruthy',
     'commands/Should-ContainCollection',
+    'commands/Should-HaveParameter',
     'commands/Should-HaveType',
+    'commands/Should-Invoke',
+    'commands/Should-MatchString',
     'commands/Should-NotBe',
     'commands/Should-NotBeEmptyString',
     'commands/Should-NotBeLikeString',
@@ -64,7 +67,10 @@ module.exports = [
     'commands/Should-NotBeString',
     'commands/Should-NotBeWhiteSpaceString',
     'commands/Should-NotContainCollection',
+    'commands/Should-NotHaveParameter',
     'commands/Should-NotHaveType',
+    'commands/Should-NotInvoke',
+    'commands/Should-NotMatchString',
     'commands/Should-Throw',
     'commands/Should'
 ];


### PR DESCRIPTION
Addresses pester/Pester#2464 — *"Make sure new assertion docs are showing up on pester.dev."*

Pester v6 ships a new `Should-*` assertion set (40 functions). The command-reference pages were last generated from **6.0.0-alpha5**, but six assertions were added afterwards and so had **no generated page** on the site.

## Command reference — add the 6 missing pages
- `Should-Invoke`, `Should-NotInvoke` (Mock)
- `Should-HaveParameter`, `Should-NotHaveParameter` (Parameter)
- `Should-MatchString`, `Should-NotMatchString` (String)

These were generated from a `main` build (which still reports `6.0.0-alpha5`, so the version footer stays consistent with the other pages). The spurious `-ProgressAction` parameter that PlatyPS emits on PowerShell 7.4+ ([platyPS#663](https://github.com/PowerShell/platyPS/issues/663), the reason CI pins PS 7.3) was stripped so the output is byte-for-byte consistent with the existing pages — verified by regenerating an unchanged page (`Should-BeString`) and diffing to an exact match. Added the six entries to the commands sidebar in alphabetical order.

## Overview page — `assertions/should-command`
- Fixed a broken ` ```powershell ` code fence that left an example block unclosed.
- Filled in the empty **Collection assertions** section (generic + combinator assertions, with examples).
- Added an **Assertion reference** catalog listing every `Should-*` assertion grouped by category, each linking to its command page.

## Validation
- `yarn build` passes with `onBrokenLinks: 'throw'` / `onBrokenMarkdownLinks: 'throw'` — no broken links.
- All six new pages render under `/docs/v6/commands/`.

> Note: the existing 34 generated pages were intentionally left untouched to keep this change focused; they'll refresh via the normal "Update Pester Docs" workflow when the next prerelease publishes.