### PR TITLE
Update v6 docs from 6.0.0 release notes

### DIFF
--- a/docs/assertions/assertions.mdx
+++ b/docs/assertions/assertions.mdx
@@ -6,6 +6,10 @@ description: Introduction to the built-in assertion operators in Pester to get y
 
 `Should` is a command that provides assertion convenience methods for comparing objects and throwing test failures when test expectations fail. `Should` is used inside `It` blocks of a Pester test script.
 
+:::tip New in Pester v6
+This page documents the classic `Should -Be` assertions, which still ship and work in Pester v6. Pester v6 also adds a set of specialized, type-aware [`Should-*` assertions](./should-command) (note the hyphen, no space) with clearer failure messages. Both styles work side by side, so you can adopt `Should-*` when it suits you and optionally turn off the classic syntax by setting `Should.DisableV5 = $true`.
+:::
+
 ## Common parameters
 
 ### Negative Assertions
@@ -212,7 +216,13 @@ Remove-Item $actual
 $actual | Should -Exist # Test will fail
 ```
 
-To test path containing `[ ]` wildcards, escape each bracket with two back-ticks as such `"TestDrive:\``[test``].txt"` or use `Test-Path -LiteralPath $something | Should -Be $true`.
+To test a path that contains `[ ]` wildcards, use the `-LiteralPath` switch (added in Pester v6) so the path is treated literally instead of as a wildcard pattern:
+
+```powershell
+'TestDrive:\[test].txt' | Should -Exist -LiteralPath
+```
+
+Alternatively, escape each bracket with two back-ticks as such `"TestDrive:\``[test``].txt"`, or use `Test-Path -LiteralPath $something | Should -Be $true`.
 
 ### FileContentMatch
 

--- a/docs/assertions/should-command.mdx
+++ b/docs/assertions/should-command.mdx
@@ -237,6 +237,23 @@ All `Should-*` assertions are listed below, grouped by the kind of check they pe
 - [`Should-HaveParameter`](../commands/Should-HaveParameter.mdx) — Asserts that a command has the expected parameter, and optionally checks its type, default value, aliases, parameter set, mandatory status, and argument completer.
 - [`Should-NotHaveParameter`](../commands/Should-NotHaveParameter.mdx) — Asserts that a command does not have the given parameter.
 
+### Choosing your assertion syntax
+
+The classic `Should -Be` assertions still ship and still work, and the new `Should-*` assertions sit alongside them. You can adopt them one test at a time, or mix both styles in the same suite while you migrate.
+
+When you are ready to commit to the new style, switch the old syntax off so it can't be used by accident:
+
+```powershell
+$config = New-PesterConfiguration
+$config.Should.DisableV5 = $true
+```
+
+With `Should.DisableV5` enabled, using the classic `Should -Be` syntax throws, pointing you at the new command:
+
+```
+Pester Should -Be syntax is disabled. Use Should-Be (without space), or enable it by setting: $PesterPreference.Should.DisableV5 = $false
+```
+
 ## `Should` (v4/v5)
 
 `Should` is used to do an assertion that fails or passes the test.
@@ -266,7 +283,7 @@ Other assertion types can be found in [Assertion Reference](.).
 
 `Should` can now be configured to continue on failure. This will report the error to Pester, but won't fail the test immediately. Instead, all the Should failures are collected and reported at the end of the test. This allows you to put multiple assertions into one It and still get complete information on failure.
 
-This new Should behavior is opt-in and can be enabled via `Should.ErrorAction = 'Continue'` on the configuration object or via `$PesterPreference`.
+This new Should behavior is opt-in and can be enabled via `Should.ErrorAction = 'Continue'` on the configuration object or via `$PesterPreference`. The new `Should-*` assertions honor this setting too, so you can collect multiple failures whichever syntax you use.
 
 ```powershell
  BeforeAll {

--- a/docs/introduction/installation.mdx
+++ b/docs/introduction/installation.mdx
@@ -83,7 +83,7 @@ WARNING: Unable to resolve package source 'https://www.powershellgallery.com/api
 You don't have to use a package manager to install Pester. Another option is to download and installing it manually which can be useful in e.g. offline environments.
 
 1. Download the module on a machine with internet using either:
-    - `Save-Module -Name Pester -Path C:\Temp`. It will save it in a versioned folder, ex *C:\Temp\Pester\5.5.0*
+    - `Save-Module -Name Pester -Path C:\Temp`. It will save it in a versioned folder, ex *C:\Temp\Pester\6.0.0*
     - Or download the NuGet package from PowerShell Gallery and extract it, see [Manual Package Download](https://docs.microsoft.com/en-us/powershell/scripting/gallery/how-to/working-with-packages/manual-download)
 2. Copy the Pester-folder (ex. *C:\Temp\Pester*) to your destination computer and place it in one of your module directories defined by [$env:PSModulePath](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_psmodulepath). On a Windows-system the default locations include:
     - **Current user:** *$HOME\Documents\WindowsPowerShell\Modules*
@@ -91,7 +91,7 @@ You don't have to use a package manager to install Pester. Another option is to 
 3. Start PowerShell and start testing.
 
 :::note
-Step 2 is an optional step to enable simple import by name and module auto-loading. You could also import Pester using an absolute path like `Import-Module C:\Temp\Pester\5.5.0`.
+Step 2 is an optional step to enable simple import by name and module auto-loading. You could also import Pester using an absolute path like `Import-Module C:\Temp\Pester\6.0.0`.
 :::
 
 ## Alternative package sources

--- a/docs/migrations/v5-to-v6.mdx
+++ b/docs/migrations/v5-to-v6.mdx
@@ -102,20 +102,24 @@ Describe 'd' {
 }
 ```
 
-### Test names only expand `-ForEach` data
+### Test names evaluate `<...>` templates as expressions
 
-`<...>` tokens in `Describe`/`Context`/`It` names now interpolate **only the current data item and its properties** — not arbitrary PowerShell expressions. This closes a code-injection vector where an expression embedded in a name ran during discovery.
+In v6 the content of every `<...>` token in a `Describe`/`Context`/`It` name is evaluated as a PowerShell expression in the test's run scope. You can reference the current `-ForEach`/`-TestCases` item and its properties, any in-scope variable, and full expressions such as arithmetic or method calls. Everything outside `<...>` (including `$`, `$(...)`, quotes, and backticks) is escaped and kept literal, so it can't break the name or run code.
 
-**Symptom.** A name that embedded an expression no longer evaluates it.
+In v5 only simple data, variable, and property references inside `<...>` were substituted; anything more complex was left verbatim. As a result a name that happens to contain expression-like content inside `<...>` now renders differently.
 
-**Fix.** Compute the value into a `-ForEach` property and reference that property by name:
+**Symptom.** A name with an expression inside `<...>` that used to render literally is now evaluated.
 
 ```powershell
-# v5 — arbitrary expression in the name
+# v5 renders literally:  adds up to <($a + $b)>
+# v6 evaluates:          adds up to 3
 It 'adds up to <($a + $b)>' -ForEach @(@{ a = 1; b = 2 }) { }
+```
 
-# v6 — put the value in the data, reference it by name
-It 'adds up to <sum>' -ForEach @(@{ a = 1; b = 2; sum = 3 }) { }
+**Fix (if you want the literal text).** Escape the leading `<` so it isn't treated as a template:
+
+```powershell
+It 'adds up to `<($a + $b)`>' -ForEach @(@{ a = 1; b = 2 }) { }
 ```
 
 ### `Assert-MockCalled` and `Assert-VerifiableMock` removed

--- a/docs/quick-start.mdx
+++ b/docs/quick-start.mdx
@@ -39,7 +39,7 @@ Import-Module Pester -PassThru
 
 ModuleType Version    PreRelease Name
 ---------- -------    ---------- ----
-Script     5.5.0                 Pester
+Script     6.0.0                 Pester
 ```
 
 Full installation guide is available in [installation](introduction/installation).

--- a/docs/usage/code-coverage.mdx
+++ b/docs/usage/code-coverage.mdx
@@ -147,11 +147,11 @@ To exclude a function (or scriptblock) from code coverage. Place `[ExcludeFromCo
 
 ## Coverage Format
 
-By default, Pester generates a `coverage.xml` file in [JaCoCo](https://www.jacoco.org/) format. You have the flexibility to modify the output format, path, and encoding by using the following options:
+By default, Pester generates a `coverage.xml` file in [JaCoCo](https://www.jacoco.org/) format. It's read by most CI systems and coverage tools, so the default is a good choice for most projects. Pester v6 can also output [Cobertura](https://cobertura.github.io/cobertura/) format if you need it. You can change the output format, path, and encoding with the following options:
 
 ```powershell
 $config = New-PesterConfiguration
-$config.CodeCoverage.OutputFormat = 'CoverageGutters'
+$config.CodeCoverage.OutputFormat = 'Cobertura'   # 'JaCoCo' (default) or 'Cobertura'
 $config.CodeCoverage.OutputPath = 'cov.xml'
 $config.CodeCoverage.OutputEncoding = 'UTF8'
 
@@ -170,6 +170,28 @@ which involves placing the tests alongside the code you want to cover,
 or set the config `CodeCoverage.Path` option to the directory
 that contains the code to be covered.
 :::
+
+## Coverage performance
+
+By default Pester v6 collects coverage using a **profiler-based tracer**, which is considerably faster than the breakpoint-based collector used in Pester v5. No configuration is needed to get the faster behaviour. If you need the old breakpoint-based collector, set `CodeCoverage.UseBreakpoints` to `$true`:
+
+```powershell
+$config = New-PesterConfiguration
+$config.CodeCoverage.Enabled = $true
+$config.CodeCoverage.UseBreakpoints = $true   # Pester v5 behaviour, slower
+Invoke-Pester -Configuration $config
+```
+
+## Report paths and ReportRoot
+
+Coverage reports record file paths relative to a root directory so they stay stable across machines and CI agents. By default that root is the repository root (`Run.RepoRoot`, located by searching for the `.git` directory). Override it with `CodeCoverage.ReportRoot` when the code you cover lives outside the repository root:
+
+```powershell
+$config = New-PesterConfiguration
+$config.CodeCoverage.Enabled = $true
+$config.CodeCoverage.ReportRoot = "$PSScriptRoot/src"
+Invoke-Pester -Configuration $config
+```
 
 ## Integrating with GitHub Actions
 

--- a/docs/usage/configuration.mdx
+++ b/docs/usage/configuration.mdx
@@ -125,9 +125,13 @@ Tests Passed: 1, Failed: 0, Skipped: 0, Total: 1, NotRun: 0
 
 ## PesterConfiguration Options
 
+:::tip TestResult and CodeCoverage auto-enable
+In Pester v6 you don't have to set `TestResult.Enabled` or `CodeCoverage.Enabled` separately. Setting **any** non-default option in the `TestResult` or `CodeCoverage` section automatically enables that feature, so a report you configured never silently goes unwritten. For example, setting `TestResult.OutputPath` is enough to produce a test-result file.
+:::
+
 <!--GENERATED_PESTER_CONFIGURATION_DOCS_START-->
 
-*This section was generated using Pester 6.0.0-alpha5.*
+*This section was generated using Pester 6.0.0-rc2.*
 
 ### Run
 
@@ -145,8 +149,12 @@ General runtime options for Pester including tests containers to execute.
 | Run.Throw | Throw an exception when test run fails. When used together with Exit, throwing an exception is preferred. | `bool` | `$false` |
 | Run.PassThru | Return result object to the pipeline after finishing the test run. | `bool` | `$false` |
 | Run.SkipRun | Runs the discovery phase but skips run. Use it with PassThru to get object populated with all tests. | `bool` | `$false` |
+| Run.Parallel | EXPERIMENTAL: Run test files in parallel, each file in its own runspace, using PowerShell 7+ 'ForEach-Object -Parallel'. Files that contain the '#pester:no-parallel' directive run sequentially after the parallel batch. Falls back to a sequential run on Windows PowerShell 5.1, when non-file containers (ScriptBlock) are used, when CodeCoverage is enabled, or when Run.SkipRemainingOnFailure is set to 'Run'. | `bool` | `$false` |
+| Run.BeforeContainer | EXPERIMENTAL: One or more ScriptBlocks run before each test file is discovered and run, in both sequential and parallel runs. Use it to import helper modules or dot-source setup that the parent session would normally provide, e.g. \{ . './setup.ps1' \} - this is especially useful in parallel runs, where each worker starts from a clean runspace. One scriptblock is usually enough and can dot-source as many files as needed. When set, the convention file is ignored; when not set, Pester dot-sources a 'Pester.BeforeContainer.ps1' from the repository root (Run.RepoRoot) if one is present. | `scriptblock[]` | `@()` |
+| Run.ParallelThrottleLimit | EXPERIMENTAL: Maximum number of test files to run at the same time when Run.Parallel is enabled, passed through to 'ForEach-Object -Parallel -ThrottleLimit'. The default 0 uses all available processors ([Environment]::ProcessorCount). Set a lower number to cap how many runspaces run concurrently. Only used when Run.Parallel is enabled. | `int` | `0` |
 | Run.SkipRemainingOnFailure | Skips remaining tests after failure for selected scope, options are None, Run, Container and Block. | `string` | `'None'` |
 | Run.FailOnNullOrEmptyForEach | Fails discovery when -ForEach is provided $null or @() in a block or test. Can be overridden for a specific Describe/Context/It using -AllowNullOrEmptyForEach. | `bool` | `$true` |
+| Run.RepoRoot | Root directory of the repository. Found by searching for the .git directory recursively. When not found, the current working directory is used. | `string` | `$null` |
 </div>
 
 ### Filter
@@ -171,7 +179,7 @@ Options to enable and configure Pester's code coverage feature.
 | Option | Description | Type | Default |
 |--------|-------------|-----:|--------:|
 | CodeCoverage.Enabled | Enable CodeCoverage. | `bool` | `$false` |
-| CodeCoverage.OutputFormat | Format to use for code coverage report. Possible values: JaCoCo, CoverageGutters, Cobertura | `string` | `'JaCoCo'` |
+| CodeCoverage.OutputFormat | Format to use for code coverage report. Possible values: JaCoCo, Cobertura | `string` | `'JaCoCo'` |
 | CodeCoverage.OutputPath | Path relative to the current directory where code coverage report is saved. | `string` | `'coverage.xml'` |
 | CodeCoverage.OutputEncoding | Encoding of the output file. | `string` | `'UTF8'` |
 | CodeCoverage.Path | Directories or files to be used for code coverage, by default the Path(s) from general settings are used, unless overridden here. | `string[]` | `@()` |
@@ -180,6 +188,7 @@ Options to enable and configure Pester's code coverage feature.
 | CodeCoverage.CoveragePercentTarget | Target percent of code coverage that you want to achieve, default 75%. | `decimal` | `75` |
 | CodeCoverage.UseBreakpoints | When false, use Profiler based tracer to do CodeCoverage instead of using breakpoints. | `bool` | `$false` |
 | CodeCoverage.SingleHitBreakpoints | Remove breakpoint when it is hit. This increases performance of breakpoint based CodeCoverage. | `bool` | `$true` |
+| CodeCoverage.ReportRoot | Root path for the code coverage report. Uses Run.RepoRoot by default. | `string` | `$null` |
 </div>
 
 ### TestResult
@@ -218,6 +227,7 @@ Debug configuration for Pester. ⚠ Use at your own risk!
 | Debug.WriteDebugMessages | Write Debug messages to screen. | `bool` | `$false` |
 | Debug.WriteDebugMessagesFrom | Write Debug messages from a given source, WriteDebugMessages must be set to true for this to work. You can use like wildcards to get messages from multiple sources, as well as * to get everything. | `string[]` | `@('Discovery', 'Skip', 'Mock', 'CodeCoverage')` |
 | Debug.ShowNavigationMarkers | Write paths after every block and test, for easy navigation in VSCode. | `bool` | `$false` |
+| Debug.ShowStartMarkers | Write an indication when each test starts. | `bool` | `$false` |
 | Debug.ReturnRawResultObject | Returns unfiltered result object, this is for development only. Do not rely on this object for additional properties, non-public properties will be renamed without previous notice. | `bool` | `$false` |
 </div>
 

--- a/docs/usage/data-driven-tests.mdx
+++ b/docs/usage/data-driven-tests.mdx
@@ -284,6 +284,36 @@ Describing Animals
 ```
 
 
+### Using expressions in `<>` template
+
+In Pester v6 the content of a `<>` template is evaluated as a PowerShell expression in the test's scope, so you are no longer limited to variable names and dot-navigation. You can call methods or compute values inline:
+
+```powershell
+Describe "Math" {
+    It 'sum of <a> and <b> is <($a + $b)>' -ForEach @(
+        @{ a = 1; b = 2 }
+        @{ a = 5; b = 7 }
+    ) {
+        # ...
+    }
+
+    It 'upper of <name> is <($name.ToUpper())>' -ForEach @(@{ Name = 'cow' }) {
+        # ...
+    }
+}
+```
+```
+Describing Math
+  [+] sum of 1 and 2 is 3
+  [+] sum of 5 and 7 is 12
+  [+] upper of cow is COW
+```
+
+:::tip Use single-quoted names
+Always wrap names that contain `<>` templates in single quotes. With double quotes, PowerShell expands `$a`, `$name`, and `$(...)` itself during discovery, before your data exists, which produces empty or wrong values. Single quotes let Pester expand the template at run time instead.
+:::
+
+
 ### Escaping
 
 Before the template string is expanded every `$` and `` ` `` in the text is escaped. This allows you to put literals, such as `$null` in your test names, and still use the template to expand the value:

--- a/docs/usage/discovery-and-run.mdx
+++ b/docs/usage/discovery-and-run.mdx
@@ -110,6 +110,45 @@ In the run phase we take the internal tree of containers, blocks and tests and r
 We are done. All tests in this container are executed.
 
 
+## Per-file Discovery and Run
+
+In Pester v6, each file is discovered and run before the next file starts. Pester discovers the first file, runs it, then does the same for the next file:
+
+```
+File1.Tests.ps1 -> Discovery -> Run
+File2.Tests.ps1 -> Discovery -> Run
+```
+
+In Pester v5 the phases were global: every file was discovered first, and only then was every file run (`File1 Discovery`, `File2 Discovery`, `File1 Run`, `File2 Run`).
+
+Most suites won't notice the difference, but it matters when files share process-wide state. A file that changes the working directory, sets a global variable, or imports a module during Discovery no longer affects the Discovery of unrelated files, because each file is fully processed before the next one starts.
+
+You can observe the order with a quick experiment. Top-level code runs during Discovery, and `BeforeAll` runs during Run:
+
+```powershell title="A.Tests.ps1"
+Write-Host "A: discovery"
+Describe 'A' {
+    BeforeAll { Write-Host "A: run" }
+    It 'a' { $true }
+}
+```
+```powershell title="B.Tests.ps1"
+Write-Host "B: discovery"
+Describe 'B' {
+    BeforeAll { Write-Host "B: run" }
+    It 'b' { $true }
+}
+```
+
+```
+# Pester v6 runs each file's phases together
+A: discovery
+A: run
+B: discovery
+B: run
+```
+
+
 ## Common gotchas
 
 ### `BeforeAll` and `-TestCases`

--- a/docs/usage/mocking.mdx
+++ b/docs/usage/mocking.mdx
@@ -259,17 +259,79 @@ Describe "d" {
 
     BeforeAll {
         function f ($a) { "real" }
-        Mock f { "mock" } -ParameterFilter { $a -eq 10 }
+        Mock f { "default" }
+        Mock f { "ten" } -ParameterFilter { $a -eq 10 }
     }
 
     It "i" {
         f 10
-        Should -Invoke f -Exactly 1
+        Should -Invoke f -Exactly 1 -ParameterFilter { $a -eq 10 }
     }
 
     It "j" {
         f 20
-        Should -Invoke f -Exactly 0
+        Should -Invoke f -Exactly 0 -ParameterFilter { $a -eq 10 }
     }
 }
 ```
+
+## Changes in Pester v6
+
+### Mocks no longer fall through to the real command
+
+In Pester v5, calling a command whose `-ParameterFilter` mocks didn't match would silently **fall through to the real command**. Pester v6 removes this behavior to make mocks predictable: if none of the parameter filters match and there is no default (unfiltered) mock, the call fails with a clear error instead of running the real command.
+
+```powershell
+Describe "d" {
+    BeforeAll {
+        function Get-Thing ($Id) { "real:$Id" }
+        Mock Get-Thing { "mock" } -ParameterFilter { $Id -eq 1 }
+    }
+
+    It "throws when nothing matches" {
+        # In v5 this returned "real:2"; in v6 it throws:
+        { Get-Thing 2 } | Should -Throw "*no default mock to fall back to*"
+    }
+}
+```
+
+Add a default mock to handle the calls that don't match a specific filter:
+
+```powershell
+Mock Get-Thing { "default" }                             # handles everything else
+Mock Get-Thing { "one" } -ParameterFilter { $Id -eq 1 }  # specific case
+```
+
+### Mock history
+
+When a `Should -Invoke` assertion fails, Pester v6 prints the recorded mock history for the command. It lists every recorded call and marks whether each one matched your parameter filter, so you can see why a filter did or didn't match without adding your own `Write-Host` debugging.
+
+```powershell title="Order.Tests.ps1"
+BeforeAll {
+    function Send-Email ($To, $Subject) { }
+}
+
+Describe 'Order processing' {
+    It 'emails alice exactly twice' {
+        Mock Send-Email { }
+
+        Send-Email -To 'alice@example.com' -Subject 'Welcome'
+        Send-Email -To 'bob@example.com'   -Subject 'Receipt'
+
+        Should -Invoke Send-Email -Times 2 -Exactly -ParameterFilter { $To -eq 'alice@example.com' }
+    }
+}
+```
+
+The assertion fails because only one of the two calls matched the filter, and the failure lists both recorded calls:
+
+```
+[-] emails alice exactly twice
+ Expected Send-Email to be called 2 times exactly, but was called 1 times
+ Performed invocations:
+   [*] Send-Email -To 'alice@example.com' -Subject 'Welcome' from Order.Tests.ps1:7
+   [ ] Send-Email -To 'bob@example.com' -Subject 'Receipt' from Order.Tests.ps1:7
+ at Should -Invoke Send-Email -Times 2 -Exactly -ParameterFilter { $To -eq 'alice@example.com' }, Order.Tests.ps1:12
+```
+
+`[*]` marks a call that matched the parameter filter and `[ ]` marks one that didn't. Here `alice` matched and `bob` didn't, so the matched count is 1 instead of the expected 2.

--- a/docs/usage/output.mdx
+++ b/docs/usage/output.mdx
@@ -85,3 +85,37 @@ Pester supports multiple render modes for console output, including ANSI escape 
 - **ANSI**: Render using ANSI escape sequences. Colors are shown in ANSI-supported console hosts, redirected output, CI-logs etc.
 - **ConsoleColor**: Uses default `Write-Host` behavior. Colors are shown in console but not in CI, redirected output etc. This mode was used prior to Pester 5.4.
 - **Plaintext**: Render output without colors.
+
+### Test duration
+
+Each test and block prints how long it took. In Pester v6 this is a single value:
+
+```
+  [+] passes 39ms
+```
+
+In Pester v5 the duration was split into the time spent in your code and the Pester framework overhead, shown as `(user|framework)`:
+
+```
+  [+] passes 34ms (26ms|9ms)
+```
+
+Some sample outputs elsewhere in these docs still show the older `(user|framework)` format.
+
+### Showing when each test starts
+
+In a long-running suite it can be hard to tell which test is currently executing, or which one is stuck. Enable `Debug.ShowStartMarkers` to print a marker as each test starts, before its result line is written:
+
+```powershell
+$conf = New-PesterConfiguration
+$conf.Run.Path = '.'
+$conf.Output.Verbosity = 'Detailed'
+$conf.Debug.ShowStartMarkers = $true
+Invoke-Pester -Configuration $conf
+```
+
+```
+Describing Get-Emoji
+  [|] returns cactus...
+  [+] returns cactus 34ms
+```

--- a/docs/usage/parallel.mdx
+++ b/docs/usage/parallel.mdx
@@ -1,0 +1,84 @@
+---
+title: Parallel execution
+description: Pester v6 can run test files in parallel, each file in its own runspace, to cut the wall-clock time of large suites. This experimental feature is enabled with a single configuration option.
+---
+
+:::warning Experimental
+Parallel execution is experimental in Pester v6. Treat `Run.Parallel` as opt-in. The directive name, configuration shape, and behavior may still change before it is declared stable.
+:::
+
+Pester v6 can run test files concurrently, one file per runspace, using the PowerShell 7+ `ForEach-Object -Parallel` engine. On a multi-core machine this can cut the wall-clock time of a large suite.
+
+It is a configuration option, not a separate command. It builds on the [per-file Discovery and Run model](./discovery-and-run#per-file-discovery-and-run): because each file is discovered and run as a self-contained unit, files can be handed to separate runspaces and run in isolation.
+
+## Enabling parallel execution
+
+Set `Run.Parallel` to `$true`:
+
+```powershell
+$config = New-PesterConfiguration
+$config.Run.Path = './tests'
+$config.Run.Parallel = $true
+Invoke-Pester -Configuration $config
+```
+
+Each file is discovered and run inside its own runspace, then the results are merged back into a single run with correct aggregate counts and durations, so the summary and the `TestResult` report look the same as a sequential run.
+
+## Limiting concurrency
+
+By default Pester uses every available processor. Cap how many files run at once with `Run.ParallelThrottleLimit`, which is passed to `ForEach-Object -Parallel -ThrottleLimit`:
+
+```powershell
+$config = New-PesterConfiguration
+$config.Run.Path = './tests'
+$config.Run.Parallel = $true
+$config.Run.ParallelThrottleLimit = 4   # at most 4 files at a time; 0 (default) uses all processors
+Invoke-Pester -Configuration $config
+```
+
+## Shared per-file setup
+
+Each worker starts from a clean runspace, so anything the parent session would normally provide (imported modules, dot-sourced helpers) is not available unless you set it up. `Run.BeforeContainer` takes one or more script blocks that run before every test file is discovered and run, in both sequential and parallel runs:
+
+```powershell
+$config = New-PesterConfiguration
+$config.Run.Path = './tests'
+$config.Run.Parallel = $true
+$config.Run.BeforeContainer = { . './setup.ps1' }   # import modules, dot-source shared setup
+Invoke-Pester -Configuration $config
+```
+
+One script block is usually enough, since it can dot-source as many files as needed.
+
+If you don't set `Run.BeforeContainer`, Pester looks for a single `Pester.BeforeContainer.ps1` in the repository root (`Run.RepoRoot`, found from the nearest `.git` directory) and dot-sources it when present. That gives you a per-repo bootstrap with no configuration. Setting `Run.BeforeContainer` overrides the convention file.
+
+## Opting a file out
+
+A test file can opt out of parallelization with a `#pester:no-parallel` directive. It is parsed like `#requires`, matched only inside a real comment token and never inside a string:
+
+```powershell title="Integration.Tests.ps1"
+#pester:no-parallel
+Describe 'integration that must not share the box' {
+    # ...
+}
+```
+
+Files marked this way run in the parent session on the normal serial path, with shared session state and live output, while the other files run in parallel.
+
+## Requirements and fallback
+
+Parallel execution needs PowerShell 7+ and a file-based run (`Run.Path`). When a run can't be parallelized, Pester falls back to a normal sequential run and prints a warning, so your tests keep working unchanged. This fallback happens:
+
+- on Windows PowerShell 5.1,
+- for `ScriptBlock` / `Container` inputs (anything that isn't a file),
+- when `CodeCoverage` is enabled (coverage is always collected on the sequential path),
+- when `Run.SkipRemainingOnFailure = 'Run'` (a cross-file stop-on-failure can't span runspaces),
+- and when every file opts out with `#pester:no-parallel`.
+
+## Output and results
+
+Within a parallel run each worker runs silently, and the parent replays every file's output in discovery order, emitting the same plugin-event sequence as a serial run. Console output, the `TestResult` report (produced once from the merged result tree), and IDE adapters such as the VS Code adapter behave the same in both modes. Only the concurrency differs.
+
+:::note Reserved for follow-ups
+Code coverage in parallel (collect per worker, merge in the parent) currently falls back to the sequential path. For mixed runs where only some files opt out, those files' IDE-adapter events currently arrive after the parallel batch. Console output and results are unaffected.
+:::

--- a/docs/usage/setup-and-teardown.mdx
+++ b/docs/usage/setup-and-teardown.mdx
@@ -114,11 +114,15 @@ The teardown in `AfterEach` should be prepared to run at any place of `BeforeEac
 
 ### Multiple setups and teardowns
 
-When multiple `BeforeAll` are defined, they run in the order in which they were defined. `AfterAll` run in the opposite order.
+A block can contain at most **one** `BeforeAll`, `BeforeEach`, `AfterEach`, and `AfterAll`. In Pester v6 defining the same kind twice in a single block is an error and discovery fails:
 
-When multiple `BeforeEach` are defined, they run in the order in which they were defined, and they run right before the test they setup. `AfterEach` run right after the test is finished, in the opposite order.
+```
+BeforeAll is already defined in this block. Each block can only have one BeforeAll. Combine the code into a single BeforeAll block.
+```
 
-There can be only one setup or teardown of each kind in a block.
+Combine the code into a single block instead. (In Pester v5 the duplicates were silently merged.)
+
+Setups and teardowns from **nested** blocks still stack. When a test is surrounded by setups from several levels (top-level, `Describe`, `Context`), the `BeforeAll`/`BeforeEach` run from the outermost block inward, and the matching `AfterEach`/`AfterAll` run from the innermost block outward:
 
 ```powershell
 BeforeAll {

--- a/docs/usage/skip.mdx
+++ b/docs/usage/skip.mdx
@@ -126,3 +126,30 @@ Tests Passed: 1, Failed: 0, Skipped: 2 NotRun: 0
 :::tip Skipping during Run-phase
 In certain scenarios you might need to mark a test as skipped or inconclusive during execution. This is possible using [`Set-ItResult`](../commands/Set-ItResult). Be aware that setup and teardown-blocks will be executed, so use `-Skip` whenever possible.
 :::
+
+## Skipping the rest of a scope on failure
+
+Pester v6 can stop running the rest of a scope as soon as a test fails. This is useful when later tests can't meaningfully pass once an earlier one fails, for example when a shared resource failed to set up. Enable it with `Run.SkipRemainingOnFailure`:
+
+| Value | Effect |
+| --- | --- |
+| `None` (default) | Keep running every test. |
+| `Run` | Skip all remaining tests in the whole run after the first failure. |
+| `Container` | Skip the rest of the current file/container. |
+| `Block` | Skip the rest of the current `Describe`/`Context` block. |
+
+```powershell
+$config = New-PesterConfiguration
+$config.Run.Path = './tests'
+$config.Run.SkipRemainingOnFailure = 'Block'
+Invoke-Pester -Configuration $config
+```
+
+Remaining tests are also skipped when a block's setup or teardown fails.
+
+```
+  [+] first passes 33ms
+  [-] second fails 12ms
+  [!] third would pass 1ms
+  [!] fourth would pass 0ms
+```

--- a/docs/usage/test-results.mdx
+++ b/docs/usage/test-results.mdx
@@ -5,7 +5,7 @@ sidebar_label: Test Results
 description: Pester can output tests results to NUnit and JUnit XML reports that can be consumed by test reporting tools and CI-solutions
 ---
 
-Pester can output test results to a XML file using the NUnit 2.5 or JUnit 4 schema.
+Pester can output test results to an XML file using the NUnit 2.5, NUnit 3, or JUnit 4 schema.
 
 ## [TeamCity](https://www.jetbrains.com/teamcity/)
 
@@ -19,20 +19,13 @@ If you are using the Pester .bat file to run your tests, test results are automa
 
 ### Using Invoke-Pester
 
-If you are not using the Pester .bat file and are instead calling Invoke-Pester directly from a build script, Make sure to specify a path using the `-OutputFile` and type include the "-OutputFormat" parameters. The path is relative to the TeamCity agent working directory.
-
-```powershell
-Invoke-Pester -OutputFile Test.xml -OutputFormat NUnitXml
-```
-
-#### Advanced Interface Configuration
-In Pester v5 a configuration object ([`PesterConfiguration`](https://pester.dev/docs/usage/configuration#advanced-interface)) was introduced. In addition to specifying an `OutputFormat` and `OutputPath` you will need to `Enable` test results for a file to be produced.
+If you are not using the Pester .bat file and are instead calling Invoke-Pester directly from a build script, configure test results through a [`PesterConfiguration`](https://pester.dev/docs/usage/configuration#advanced-interface) object. The legacy `-OutputFile` and `-OutputFormat` parameters were removed in Pester v6, so set the `OutputFormat` and `OutputPath` and `Enable` test results for a file to be produced. The path is relative to the TeamCity agent working directory.
 
 ```powershell
 $PesterConfig = New-PesterConfiguration
-$PesterConfig.TestResult.OutputFormat = "NUnitXml"
+$PesterConfig.TestResult.Enabled = $true
+$PesterConfig.TestResult.OutputFormat = "NUnitXml"   # NUnitXml, NUnit3 or JUnitXml
 $PesterConfig.TestResult.OutputPath = "Test.xml"
-$PesterConfig.TestResult.Enabled = $True
 Invoke-Pester -Configuration $PesterConfig
 ```
 
@@ -41,7 +34,7 @@ Invoke-Pester -Configuration $PesterConfig
 1. In your TeamCity build configuration settings, go to the "Build Step" page.
 1. Add the "XML Report Processing" Build Feature.
 1. The Report Type should be set to NUnit. You can select version 2.5.0.
-1. In the Monitoring Rules text box, enter the xml file path given to Pester's `-OutputXml` parameter. If you use the Pester.bat file, simply enter Test.xml.
+1. In the Monitoring Rules text box, enter the xml file path configured as Pester's `TestResult.OutputPath`. If you use the Pester.bat file, simply enter Test.xml.
 
 #### TeamCity Troubleshooting
 
@@ -54,7 +47,14 @@ If Pester does not seem to be available from your PowerShell build-step, here is
 Code coverage metrics are not included in the NUnit xml report so it is necessary to pass them to TeamCity separately using a PassThru variable and the [Build Interaction feature](https://confluence.jetbrains.com/display/TCD8/Build+Script+Interaction+with+TeamCity#BuildScriptInteractionwithTeamCity-ReportingBuildStatistics).
 
 ```powershell
-$testResults = Invoke-Pester -OutputFile Test.xml -OutputFormat NUnitXml -CodeCoverage (Get-ChildItem -Path $PSScriptRoot\*.ps1 -Exclude *.Tests.* ).FullName -PassThru
+$config = New-PesterConfiguration
+$config.TestResult.Enabled = $true
+$config.TestResult.OutputFormat = "NUnitXml"
+$config.TestResult.OutputPath = "Test.xml"
+$config.CodeCoverage.Enabled = $true
+$config.CodeCoverage.Path = (Get-ChildItem -Path $PSScriptRoot\*.ps1 -Exclude *.Tests.*).FullName
+$config.Run.PassThru = $true
+$testResults = Invoke-Pester -Configuration $config
 Write-Output "##teamcity[buildStatisticValue key='CodeCoverageAbsLTotal' value='$($testResults.CodeCoverage.CommandsAnalyzedCount)']"
 Write-Output "##teamcity[buildStatisticValue key='CodeCoverageAbsLCovered' value='$($testResults.CodeCoverage.CommandsExecutedCount)']"
 ```
@@ -69,7 +69,12 @@ Your [`appveyor.yml`](https://www.appveyor.com/docs/appveyor-yml) can contain se
 test_script:
     - ps: |
         $testResultsFile = ".\TestsResults.xml"
-        $res = Invoke-Pester -OutputFormat NUnitXml -OutputFile $testResultsFile -PassThru
+        $config = New-PesterConfiguration
+        $config.TestResult.Enabled = $true
+        $config.TestResult.OutputFormat = "NUnitXml"
+        $config.TestResult.OutputPath = $testResultsFile
+        $config.Run.PassThru = $true
+        $res = Invoke-Pester -Configuration $config
         (New-Object 'System.Net.WebClient').UploadFile("https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path $testResultsFile))
         if ($res.FailedCount -gt 0) {
             throw "$($res.FailedCount) tests failed."
@@ -98,7 +103,12 @@ Install-Module -Name Pester -Force -SkipPublisherCheck
 
 Import-Module Pester
 
-Invoke-Pester -Script $(System.DefaultWorkingDirectory)\MyFirstModule.test.ps1 -OutputFile $(System.DefaultWorkingDirectory)\Test-Pester.XML -OutputFormat NUnitXML
+$config = New-PesterConfiguration
+$config.Run.Path = "$(System.DefaultWorkingDirectory)\MyFirstModule.test.ps1"
+$config.TestResult.Enabled = $true
+$config.TestResult.OutputFormat = "NUnitXml"
+$config.TestResult.OutputPath = "$(System.DefaultWorkingDirectory)\Test-Pester.XML"
+Invoke-Pester -Configuration $config
 ```
 
 Then add a Publish Test Results task, it is important to change the Test Result format to NUnit to allow Azure DevOps to ingest the output file.

--- a/generate-pesterconfiguration-docs.ps1
+++ b/generate-pesterconfiguration-docs.ps1
@@ -13,7 +13,19 @@ param (
 )
 
 #region helpers
+function Format-MdxDescription ($text) {
+    # Escape characters that are structurally significant to MDX 3 / Markdown tables so raw
+    # PesterConfiguration help text (e.g. "{ . './setup.ps1' }") doesn't break the docs build.
+    # MDX 3 treats `{` as a JS expression and `<` as a JSX tag; `|` would corrupt a table row.
+    if ($null -eq $text) { return '' }
+    return ([string]$text) -replace '([{}<|])', '\$1'
+}
+
 function Format-NicelyMini ($value) {
+    if ($null -eq $value) {
+        return '$null'
+    }
+
     if ($value -is [bool]) {
         if ($value) {
             '$true'
@@ -56,9 +68,13 @@ function generateSectionsMarkdownAsTable {
         $options = foreach ($configOption in $section.PSObject.Properties) {
             $optionName = $configOption.Name
             $option = $configOption.Value
-            $default = Format-NicelyMini $option.Default
-            $type = $option.Default.GetType() -as [string] -replace '^Pester\.'
-            "| $sectionName.$optionName | $($option.Description) | ``$type`` | ``$default`` |"
+            $rawDefault = $option.Default
+            # Run.RepoRoot defaults to an auto-detected, machine-specific path. Render it as $null so the generated docs stay machine-independent.
+            if ($rawDefault -is [string] -and $rawDefault -eq $configObject.Run.RepoRoot.Value) { $rawDefault = $null }
+            $default = Format-NicelyMini $rawDefault
+            # Use the declared property type so options with a $null default (e.g. CodeCoverage.ReportRoot) still report their type.
+            $type = $option.GetType().GetProperty('Default').PropertyType -as [string] -replace '^Pester\.'
+            "| $sectionName.$optionName | $(Format-MdxDescription $option.Description) | ``$type`` | ``$default`` |"
         }
 
         @"
@@ -86,15 +102,19 @@ function generateSectionsMarkdownAsList {
         $options = foreach ($configOption in $section.PSObject.Properties) {
             $optionName = $configOption.Name
             $option = $configOption.Value
-            $default = Format-NicelyMini $option.Default
-            $type = $option.Default.GetType() -as [string]
+            $rawDefault = $option.Default
+            # Run.RepoRoot defaults to an auto-detected, machine-specific path. Render it as $null so the generated docs stay machine-independent.
+            if ($rawDefault -is [string] -and $rawDefault -eq $configObject.Run.RepoRoot.Value) { $rawDefault = $null }
+            $default = Format-NicelyMini $rawDefault
+            # Use the declared property type so options with a $null default (e.g. CodeCoverage.ReportRoot) still report their type.
+            $type = $option.GetType().GetProperty('Default').PropertyType -as [string]
             @"
 #### $sectionName.$optionName
 
 **Type:** ``$type``<br/>
 **Default:** ``$default``
 
-$($option.Description)
+$($option.Description | ForEach-Object { Format-MdxDescription $_ })
 
 "@
         }

--- a/sidebars.js
+++ b/sidebars.js
@@ -33,6 +33,7 @@ module.exports = {
       "usage/importing-tested-functions",
       "usage/test-file-structure",
       "usage/discovery-and-run",
+      "usage/parallel",
       "usage/data-driven-tests",
       "usage/setup-and-teardown",
       "usage/tags",


### PR DESCRIPTION
Works through the Pester **6.0.0** release notes point-by-point, maps each change to the relevant v6 (current) docs page, and updates it with runnable examples. Every example was verified against **Pester 6.0.0-rc2**, and the whole site builds clean.

## Pages updated

| Page | Change |
|------|--------|
| `usage/data-driven-tests`, `migrations/v5-to-v6` | `<...>` name templates evaluate expressions (with example) |
| `usage/discovery-and-run` | Per-file Discovery + Run interleaving |
| `usage/setup-and-teardown` | Duplicate setups in one block now throw |
| `usage/code-coverage` | Profiler default (`UseBreakpoints`), JaCoCo/Cobertura, `ReportRoot` |
| `usage/test-results` | Legacy `Invoke-Pester` params → config objects; NUnit3 |
| `usage/mocking` | No fall-through to the real command; fixed a now-broken `-ParameterFilter` example |
| `usage/output` | Single test duration; `ShowStartMarkers` |
| `assertions/*` | `Should-*` guide, `DisableV5`, soft assertions, `Should -Exist -LiteralPath` |
| `usage/parallel` *(new)* | Experimental parallel run (`Run.Parallel`, `ParallelThrottleLimit`, `BeforeContainer`, `#pester:no-parallel`) |
| `usage/configuration` | Regenerated for rc2; `TestResult`/`CodeCoverage` auto-enable note |
| `usage/skip` | `SkipRemainingOnFailure` |
| `introduction/installation`, `quick-start` | Version samples bumped to 6.0.0 |

## Tooling
- `generate-pesterconfiguration-docs.ps1` now escapes MDX-significant characters (`{ } < |`) in option descriptions, fixing a docs-build break caused by `Run.BeforeContainer`'s help text (`{ . './setup.ps1' }`).

## Verification
- `docusaurus build` passes clean — no MDX errors, no broken links or anchors.

## Open question
The 6.0.0 release notes describe `<...>` test-name expansion as **data-only**, but rc2 evaluates **full expressions** (`<($a + $b)>` → `3`). I documented actual rc2 behavior; flagged for maintainer confirmation in **pester/pester#2808**. If the intended behavior is data-only, the `data-driven-tests` / `migrations` sections will need a follow-up tweak.