### PR TITLE
Correct v6 `<...>` name-template internals

### DIFF
--- a/docs/usage/data-driven-tests.mdx
+++ b/docs/usage/data-driven-tests.mdx
@@ -316,7 +316,7 @@ Always wrap names that contain `<>` templates in single quotes. With double quot
 
 ### Escaping
 
-Before the template string is expanded every `$` and `` ` `` in the text is escaped. This allows you to put literals, such as `$null` in your test names, and still use the template to expand the value:
+Before the name is expanded, every `` ` ``, `$` and `"` *outside* of a `<...>` template is escaped and kept literal. This allows you to put literals, such as `$null`, in your test names, and still use a template to expand the value:
 
 ```powershell
 Describe "Fruit" -ForEach "🍎", "🍐" {
@@ -374,27 +374,21 @@ Describing When x < 4, x: 4
 
 #### Internals
 
-The value in the string is escaped by adding `` ` `` before every `$` and `` ` ``. Every template is prefixed by `$`, and then the string is expanded:
+Pester rewrites *only* the `<...>` tokens in the name; the rest of the string is never re-parsed, so literal text can't break the name or run code. Each `<expression>` is turned into a sub-expression that evaluates the content and renders the result through Pester's formatter, every other `` ` ``, `$` and `"` is escaped so it stays literal, and the assembled string is then expanded in the test's (or block's) run scope:
 
 ```
-"<x> should not be `$null"
+# the name Pester receives (write it single-quoted so $null stays literal)
+'<x> should not be $null'
 
-# because this is double quoted string it will be
-# expanded by powershell to
+# only the <x> token becomes a sub-expression that evaluates $x and formats the
+# result; the literal `$` is escaped so it stays inert
+$(Format-NicelyForTemplate $x) should not be `$null
 
-<x> should not be $null
-
-# then escaped by us to
-<x> should not be `$null
-
-# template is replaced
-$x should not be `$null
-
-# and then it is evaluated in the appropriate script scope
+# that string is expanded in the appropriate script scope
 $x = 1
-& { "$x should not be `$null" }
+& { "$(Format-NicelyForTemplate $x) should not be `$null" }
 
-# giving the final text
+# the formatter renders the value, giving the final text
 1 should not be $null
 ```
 


### PR DESCRIPTION
The **Internals** and **Escaping** notes under *Using `<>` templates* still described the pre-6.0 mechanism: the whole name re-parsed as a double-quoted string and each template merely *prefixed with `$`*. That is no longer how 6.0 works.

In 6.0 (see pester/Pester#2740) only the `<...>` tokens are rewritten into sub-expressions — evaluated and rendered through Pester's formatter — while every other backtick, `$` and `"` is escaped and kept literal, so the rest of the name is **never re-parsed** and literal text can't break the name or run code.

This updates the explanation and the worked example to match, and fixes the *Escaping* sentence to note that `"` is escaped too and that escaping applies *outside* `<...>`.

Verified the live behavior against Pester 6.0.0 (PowerShell 7.5.5):

```
adds up to <($a + $b)>            => adds up to 3
<($a.ToString("000"))>           => 007
<a> `$($global:x = $true)`       => literal, does not execute
```

Site builds clean (`npm run build`, no MDX or broken-link warnings).

Towards pester/Pester#2808 (closing keywords don't cross repos, so this won't auto-close it).