### PR TITLE
Claim PowerShell 7.4+ support instead of 7.2+

### DIFF
--- a/docs/introduction/installation.mdx
+++ b/docs/introduction/installation.mdx
@@ -9,7 +9,7 @@ description: Pester is a cross-platform PowerShell module for testing your Power
 
 Pester is a cross-platform module that runs on Windows, Linux, MacOS and anywhere else running a supported version of PowerShell. Pester currently requires and is tested with:
 - Windows PowerShell 5.1
-- PowerShell 7.2 and above
+- PowerShell 7.4 and above
 
 ## Installing from PowerShell Gallery
 

--- a/docs/migrations/v5-to-v6.mdx
+++ b/docs/migrations/v5-to-v6.mdx
@@ -13,7 +13,7 @@ Your existing `Should -Be` assertions keep working, so you don't have to rewrite
 
 For most suites upgrading is low risk. Run through this list, then read the details below for anything that bites:
 
-1. Make sure you run **Windows PowerShell 5.1** or **PowerShell 7.2+**.
+1. Make sure you run **Windows PowerShell 5.1** or **PowerShell 7.4+**.
 2. Check any `-ForEach`/`-TestCases` that can be empty — it now throws unless you add `-AllowNullOrEmptyForEach`.
 3. Remove duplicate `BeforeAll`/`BeforeEach`/`AfterAll`/`AfterEach` in the same block.
 4. Replace `Assert-MockCalled` / `Assert-VerifiableMock` with `Should -Invoke` / `Should -InvokeVerifiable`.
@@ -22,9 +22,9 @@ For most suites upgrading is low risk. Run through this list, then read the deta
 
 ## Breaking changes
 
-### PowerShell 5.1 and 7.2+ only
+### PowerShell 5.1 and 7.4+ only
 
-Support for PowerShell 3, 4, 6 and early/unsupported 7 was removed — they are all out of support from Microsoft. Dropping them let us move the C# to .NET 8 (net462 for Windows PowerShell 5.1) and modernize the runtime. Pester 6 targets **Windows PowerShell 5.1** and **PowerShell 7.2+**.
+Support for PowerShell 3, 4, 6 and early/unsupported 7 was removed — they are all out of support from Microsoft. Dropping them let us move the C# to .NET 8 (net462 for Windows PowerShell 5.1) and modernize the runtime. Pester 6 targets **Windows PowerShell 5.1** and **PowerShell 7.4+**.
 
 **Symptom.** Pester does not import on an older PowerShell.
 


### PR DESCRIPTION
## Summary

Pester 6 ships a `net8.0` assembly for PowerShell 7 (plus `net462` for Windows PowerShell 5.1). A `net8.0` assembly **cannot load** on the .NET 6 / .NET 7 runtimes used by PowerShell **7.2** / **7.3**, so claiming support for those versions is inaccurate. They are also both out of support from Microsoft per the [PowerShell support lifecycle](https://learn.microsoft.com/en-us/powershell/scripting/install/powershell-support-lifecycle?view=powershell-7.6) — the oldest supported release is **7.4 (LTS, .NET 8)**.

## Changes

- `docs/introduction/installation.mdx` — "PowerShell 7.2 and above" → "PowerShell 7.4 and above".
- `docs/migrations/v5-to-v6.mdx` — "PowerShell 7.2+" support claims (heading + body) → "PowerShell 7.4+".

Companion to pester/Pester#2811, which fixes the same claim in the README and the 6.0.0 release notes.