### PR TITLE
Document the piped-collection assertion hint for v6

### DIFF
--- a/docs/migrations/v5-to-v6.mdx
+++ b/docs/migrations/v5-to-v6.mdx
@@ -233,6 +233,27 @@ Pester 6 adds a new family of `Should-*` assertions — `Should-Be`, `Should-Thr
 
 If you want to try them, see the [command reference](../commands/Should-Be). A dedicated guide for moving from `Should -Be` to `Should-Be` will come later.
 
+### Piping vs. `-Actual`
+
+The new assertions take the actual value from the pipeline or from `-Actual`. The pipeline unwraps its input, so a **value** assertion sees `@(1)` as `1` and `@()` as `$null`, and a collection sent through the pipeline is re-collected as `[object[]]` — its original type (for example `[int[]]`) is lost. Use `-Actual` when you need the exact value or the concrete collection type:
+
+```powershell
+@(1) | Should-Be 1                                           # pipeline unwraps @(1) to 1
+Should-HaveType -Actual ([int[]](1, 2)) -Expected ([int[]])  # -Actual keeps the [int[]]
+```
+
+If a value or type assertion fails because the pipeline unwrapped a collection this way, the failure message adds a hint that explains what happened and points you back to `-Actual`:
+
+```powershell
+[int[]](1, 2) | Should-HaveType ([int[]])
+# Expected value to have type [int[]], but got [Object[]] @(1, 2).
+#
+# Hint: You piped a [int[]] into a type assertion, but the pipeline streams a multi-item
+# collection and re-collects it as [Object[]], so the assertion saw [Object[]], not the
+# [int[]] you piped. To assert the type of a collection, pass it as the -Actual argument
+# instead of piping it, e.g. -Actual $value.
+```
+
 :::warning Pester 6.0.0 is in preview
 Some details may still change before the final release. To keep up with the latest development, see the release notes for 6.0.0 pre-release builds at https://github.com/pester/Pester/releases
 :::

--- a/docs/migrations/v5-to-v6.mdx
+++ b/docs/migrations/v5-to-v6.mdx
@@ -254,6 +254,8 @@ If a value or type assertion fails because the pipeline unwrapped a collection t
 # instead of piping it, e.g. -Actual $value.
 ```
 
+The hint is best-effort. PowerShell can't reliably tell a single-item collection from a scalar, and a collection's original type isn't visible on the right-hand side of the pipeline. Pester recovers the piped value through pipeline tricks that work for common cases but not every one, so the hint won't appear in every situation. When you need the exact value or the concrete collection type, pass it with `-Actual` rather than relying on the hint.
+
 :::warning Pester 6.0.0 is in preview
 Some details may still change before the final release. To keep up with the latest development, see the release notes for 6.0.0 pre-release builds at https://github.com/pester/Pester/releases
 :::


### PR DESCRIPTION
Adds a `### Piping vs. `-Actual`` subsection to the "New `Should-*` assertions (optional)" section of the v5-to-v6 migration guide.

It explains that the new `Should-*` assertions take their actual value either from the pipeline or from `-Actual`. Because the pipeline unwraps its input, a value assertion sees `@(1)` as `1` and `@()` as `$null`, and a piped collection is re-collected as `[object[]]` (losing its original type such as `[int[]]`). The subsection shows how to use `-Actual` to preserve the exact value or concrete collection type, and documents the new failure-path hint that explains what happened and points users back to `-Actual`.

Only `docs/migrations/v5-to-v6.mdx` is touched; the auto-generated `docs/commands/Should-*.mdx` files are left untouched.

Docs for pester/Pester#2806.