### PR TITLE
docs: v6 audit follow-ups — fix dead course link

### DIFF
--- a/docs/additional-resources/courses.table.js
+++ b/docs/additional-resources/courses.table.js
@@ -7,7 +7,7 @@ export const courses = [
   {
     title: "Testing PowerShell with Pester",
     author: "Ashley McGlone, Adam Bertram",
-    url: "https://mva.microsoft.com/en-US/training-courses/17650?l=mg8oBM9vD_8811787177",
+    url: "https://learn.microsoft.com/en-us/shows/testing-powershell-with-pester/",
   },
   {
     title: "PSKoans - A simple, fun, and interactive way to learn the PowerShell language through Pester unit testing",


### PR DESCRIPTION
Follow-up to #386 (v6 docs audit).

## Change
- **Fix dead Microsoft Virtual Academy course link.** MVA was retired; the "Testing PowerShell with Pester" course now lives on Microsoft Learn. The old `mva.microsoft.com` URL only resolves via a redirect, so this points the resources table at the canonical Learn URL (`https://learn.microsoft.com/en-us/shows/testing-powershell-with-pester/`, verified `200`).

Build passes clean (no broken links).

## Remaining audit backlog (intentionally **not** changed here)
These need your call as the framework author rather than a mechanical edit:

- **Custom `Should-*` authoring** (`custom-assertions.mdx`) — the page documents the public `Add-ShouldOperator` mechanism. The internal helpers the built-in `Should-*` assertions use (`Invoke-AssertionFailed`, `Collect-Input`, `Get-AssertionMessage`, `Set-AssertionPassResult`) are **not exported**, so there's no public API to author built-in-style custom `Should-*` assertions yet. A plain function that throws (defined in `BeforeAll`) does work as an assertion, but without the built-in message formatting. Left for the "dedicated guide" you already signposted in the migration page.
- **v5→v6 guide structure** (`v5-to-v6.mdx`) — could mirror the v4→v5 guide's structure (overview of the new result object / interfaces). Authoring decision.
- **`Run.Parallel` "PowerShell 7+" wording** (`configuration.mdx`) — reviewed, left as-is: it's accurate (`ForEach-Object -Parallel` needs PS7+) and the text is sourced from the `PesterConfiguration` object, so it belongs upstream.

Co-authored-by: Copilot &lt;223556219+Copilot@users.noreply.github.com&gt;