### PR TITLE
docs: point migration guides at Pester AI migration skills

### DIFF
--- a/docs/migrations/v3-to-v4.mdx
+++ b/docs/migrations/v3-to-v4.mdx
@@ -7,6 +7,10 @@ description: Migration from Pester v3 to v4 may require minor changes to your te
 
 Migration from Pester 3 to 4 typically involves minor changes to test code. Sometimes the migration requires no changes at all. This guide is meant to help you understand and make the necessary changes to your existing test code to accommodate Pester 4.
 
+:::tip Migrate with an AI assistant
+The [`pester-migration` skill](./v5-to-v6#migrate-with-an-ai-assistant) for GitHub Copilot and other agents can do this v3→v4 upgrade for you — it follows this guide, runs your tests, and fixes them file by file. Install it with `gh skills install github/awesome-copilot pester-migration`.
+:::
+
 ## Update to New Names
 
 We recommend performing string replacement on tests written for Pester 3 and earlier as follows:

--- a/docs/migrations/v4-to-v5.mdx
+++ b/docs/migrations/v4-to-v5.mdx
@@ -7,6 +7,10 @@ description: Pester v5 introduced some fundamental changes compared with Pester 
 
 The fundamental change in this release is that Pester now runs in two phases: Discovery and Run. During discovery, it quickly scans your test files and discovers all the Describes, Contexts, Its and other Pester blocks.
 
+:::tip Migrate with an AI assistant
+This is the hardest jump — the two-phase runtime changes how tests are structured, so it isn't a pure find-replace. The [`pester-migration` skill](./v5-to-v6#migrate-with-an-ai-assistant) for GitHub Copilot and other agents knows these rules and can do the upgrade for you, running your tests and fixing them file by file. Install it with `gh skills install github/awesome-copilot pester-migration`, then review the diff.
+:::
+
 **Put all your test-code into `It`, `BeforeAll`, `BeforeEach`, `AfterAll` or `AfterEach`. Put no test-code directly into `Describe`, `Context` or on the top of your file, without wrapping it in one of these blocks, unless you have a good reason to do so.**
 
 **All misplaced code will run during Discovery, and its results won't be available during Run. Code meant to run in Discovery should be explicitly placed into `BeforeDiscovery`, see [Data driven tests](../usage/data-driven-tests#beforediscovery).**

--- a/docs/migrations/v5-to-v6.mdx
+++ b/docs/migrations/v5-to-v6.mdx
@@ -20,6 +20,43 @@ For most suites upgrading is low risk. Run through this list, then read the deta
 5. Add a default `Mock` for commands where some calls don't match a `-ParameterFilter` — mocks no longer fall through to the real command.
 6. If you script `Invoke-Pester` with v4-style parameters (`-Script`, `-OutputFile`, ...), switch to `New-PesterConfiguration`.
 
+## Migrate with an AI assistant
+
+If you use an AI coding agent that supports the [Agent Skills](https://agentskills.io/specification) spec (such as GitHub Copilot or Claude), two community **skills** in [github/awesome-copilot](https://github.com/github/awesome-copilot) teach the agent to do these migrations the way this guide describes. The agent loads a skill on demand when you ask it to upgrade a suite, so instead of guessing it follows the documented symptom → fix steps, runs your tests, and fixes them file by file.
+
+:::note Experimental / preview
+Both skills track Pester 6 while it is a release candidate, so their guidance may change alongside the release. Always review the diff and re-run your suite afterward — treat the agent as an assistant, not an unchecked bulk-editor.
+:::
+
+| Skill | What it does |
+|---|---|
+| [`pester-migration`](https://github.com/github/awesome-copilot/tree/main/skills/pester-migration) | The main upgrade skill. Takes a suite across major versions — v3→v4, v4→v5, and **v5→v6** — one major at a time: the Discovery/Run model, moving setup into `BeforeAll`, the mock changes, `Invoke-Pester` → `New-PesterConfiguration`, `-ForEach`/`-TestCases`, and every v6 breaking change on this page. |
+| [`pester-should-migration`](https://github.com/github/awesome-copilot/tree/main/skills/pester-should-migration) | The *optional* assertion move: rewrites classic `Should -Be` (v5) to the new [`Should-*`](#should-assertions) (v6) syntax and handles the behavioral gotchas (truthy vs. true, `BeNullOrEmpty`, collection semantics). |
+
+### Install the skills
+
+Install with the [GitHub CLI](https://github.blog/changelog/2026-04-16-manage-agent-skills-with-github-cli/) (v2.90.0 or newer):
+
+```powershell
+# The main migration skill (any version -> v6)
+gh skills install github/awesome-copilot pester-migration
+
+# Optional: migrate Should -Be to the new Should-Be syntax
+gh skills install github/awesome-copilot pester-should-migration
+```
+
+You can also copy the skill folder from the repo into your agent's skills directory by hand. The full catalog is in the [awesome-copilot skills list](https://github.com/github/awesome-copilot/blob/main/docs/README.skills.md).
+
+### Use them
+
+Once a skill is installed, ask your agent in plain language and it picks up the matching skill automatically:
+
+- *"Upgrade this Pester test suite to v6."*
+- *"My `*.Tests.ps1` files broke after I bumped Pester — fix them."*
+- *"Convert the `Should -Be` assertions in `./tests` to the new `Should-*` syntax."*
+
+The agent records a baseline run, applies the changes, and re-runs until the suite is green — the same loop this guide describes. Review the diff before you commit.
+
 ## Breaking changes
 
 ### PowerShell 5.1 and 7.4+ only
@@ -241,9 +278,9 @@ The per-file model lets v6 run whole test files concurrently, each in its own ru
 
 In a long or stuck suite it can be hard to tell which test is executing. Set `Debug.ShowStartMarkers = $true` to print a marker as each test starts, before its result line is written. See [Showing when each test starts](../usage/output#showing-when-each-test-starts).
 
-### New `Should-*` assertions
+### New `Should-*` assertions {#should-assertions}
 
-Pester 6 adds a new family of `Should-*` assertions — `Should-Be`, `Should-Throw`, `Should-Invoke` and around 40 more — with clearer failure messages. They are **not** part of upgrading: your existing `Should -Be` assertions keep working, and there is no need to rewrite them. If you want to try them, see the [Should assertions overview](../assertions/should-command) and the per-command reference. You can adopt them incrementally, one file at a time.
+Pester 6 adds a new family of `Should-*` assertions — `Should-Be`, `Should-Throw`, `Should-Invoke` and around 40 more — with clearer failure messages. They are **not** part of upgrading: your existing `Should -Be` assertions keep working, and there is no need to rewrite them. If you want to try them, see the [Should assertions overview](../assertions/should-command) and the per-command reference. You can adopt them incrementally, one file at a time — or let the [`pester-should-migration` skill](#migrate-with-an-ai-assistant) convert a suite for you.
 
 #### Piping vs. `-Actual`
 


### PR DESCRIPTION
## What

Documents the two Pester migration **skills** published to [github/awesome-copilot](https://github.com/github/awesome-copilot) so readers can use an AI assistant (GitHub Copilot, Claude, etc.) to upgrade their suites.

- **v5-to-v6 guide** — new `## Migrate with an AI assistant` section covering both skills, with install commands (`gh skills install github/awesome-copilot <skill>`), usage prompts, and an *experimental/preview* note (the skills track the Pester 6 RC).
- **`Should-*` section** — given a stable `{#should-assertions}` anchor and now links the `pester-should-migration` skill.
- **v3-to-v4 & v4-to-v5 guides** — short `:::tip` pointer to the `pester-migration` skill, linking back to the detailed section.

| Skill | Role |
|---|---|
| [`pester-migration`](https://github.com/github/awesome-copilot/tree/main/skills/pester-migration) | main upgrade skill — v3→v4, v4→v5, **v5→v6** |
| [`pester-should-migration`](https://github.com/github/awesome-copilot/tree/main/skills/pester-should-migration) | optional `Should -Be` → `Should-*` rewrite |

## Why

Addresses the request in pester/Pester#2680 for a supported Pester skill for AI tools — this points users at the skills and shows how to install and use them.

## Verification

- `yarn build` succeeds with no broken-link or anchor warnings.
- Cross-page anchor links from v3-to-v4 / v4-to-v5 to the new v5-to-v6 section resolve.

Refs pester/Pester#2680


Closes #390
