### PR TITLE
docs: add dedicated "Soft assertions" page (#385)

### DIFF
--- a/docs/assertions/should-command.mdx
+++ b/docs/assertions/should-command.mdx
@@ -277,50 +277,8 @@ Other assertion types can be found in [Assertion Reference](.).
 
 ### Collect all Should failures
 
-`Should` can now be configured to continue on failure. This will report the error to Pester, but won't fail the test immediately. Instead, all the Should failures are collected and reported at the end of the test. This allows you to put multiple assertions into one It and still get complete information on failure.
+`Should` can be configured to continue on failure instead of stopping the test at the first error. Every failure is collected and reported together at the end of the test, so you can put multiple assertions into one `It` and still get complete information on failure. This is called a **soft assertion**, and it works for both the classic `Should -Be` syntax and the new `Should-*` assertions.
 
-This new Should behavior is opt-in and can be enabled via `Should.ErrorAction = 'Continue'` on the configuration object or via `$PesterPreference`. The new `Should-*` assertions honor this setting too, so you can collect multiple failures whichever syntax you use.
+Enable it globally by setting `Should.ErrorAction = 'Continue'` on the configuration object (or via `$PesterPreference`), and override it on a single assertion with `-ErrorAction Stop` / `-ErrorAction Continue`.
 
-```powershell
- BeforeAll {
-    function Get-User {
-        @{
-            Name = "Jakub"
-            Age = 31
-        }
-    }
-}
-
-Describe "describe" {
-    It "user" {
-        $user = Get-User
-
-        $user | Should -Not -BeNullOrEmpty -ErrorAction Stop
-        $user.Name | Should -Be "Tomas"
-        $user.Age | Should -Be 27
-
-    }
-}
-
-```
-
-```
-Running tests from 1 files.
-
-Running tests from 'C:\t\describe.Tests.ps1'
-Describing describe
-  [-] user 124ms
-   [0] Expected strings to be the same, but they were different.
-   String lengths are both 5.
-   Strings differ at index 0.
-   Expected: 'Tomas'
-   But was:  'Jakub'
-              ^
-   at $user.Name | Should -Be "Tomas", C:\t\describe.Tests.ps1:15
-   [1] Expected 27, but got 31.
-   at $user.Age | Should -Be 27, C:\t\describe.Tests.ps1:16
-Tests completed in 286ms
-Tests Passed: 0, Failed: 1, Skipped: 0, Inconclusive: 0, NotRun: 0
-```
-
-This allows you to check complex objects easily without writing It for each of the properties that you want to test. You can also use `-ErrorAction Stop` to force a failure when a pre-condition is not met. In our case if `$user` was null, there would be no point in testing the object further and we would fail the test immediately.
+See [Soft assertions](./soft-assertions) for the full explanation, examples, and how to guard preconditions.

--- a/docs/assertions/soft-assertions.mdx
+++ b/docs/assertions/soft-assertions.mdx
@@ -1,0 +1,122 @@
+---
+title: Soft assertions
+description: Soft assertions let Pester collect every assertion failure in a test instead of stopping at the first one. Enable them globally with Should.ErrorAction = 'Continue'.
+---
+
+## What are soft assertions?
+
+By default a Pester assertion is a **hard assertion**: the first time it fails it throws, the test stops immediately, and any assertions that come after it never run. If a test contains several checks you only ever see the first failure, fix it, run again, see the next one, and so on.
+
+**Soft assertions** change that behavior. When soft assertions are enabled, a failing assertion is *recorded* but does **not** stop the test. Pester keeps going, runs the remaining assertions, and then reports **all** of the collected failures together at the end of the test. This lets you put several related checks in a single `It` and learn everything that is wrong in one run.
+
+Soft assertions are controlled by the `Should.ErrorAction` configuration option:
+
+- `Should.ErrorAction = 'Stop'` (the default) — hard assertions. The test fails on the first assertion error.
+- `Should.ErrorAction = 'Continue'` — soft assertions. Failures are collected and reported at the end of the test.
+
+This single setting is honoured by **both** assertion styles in Pester v6: the classic `Should -Be` syntax and the new [`Should-*` assertions](./should-command). You do not have to opt in per assertion — turn it on once and every assertion in the run becomes soft.
+
+## Enable soft assertions for every assertion
+
+Soft assertions are enabled globally through the [configuration object](../usage/configuration). Set `Should.ErrorAction` to `'Continue'` and every assertion in the run is collected instead of throwing on the first failure.
+
+```powershell
+$config = New-PesterConfiguration
+$config.Should.ErrorAction = 'Continue'
+
+Invoke-Pester -Configuration $config
+```
+
+You can achieve the same when running interactively (for example with `F5` in VS Code) by setting `$PesterPreference`. This is also handy in a PowerShell profile to make soft assertions the default for your session:
+
+```powershell
+$PesterPreference = New-PesterConfiguration
+$PesterPreference.Should.ErrorAction = 'Continue'
+```
+
+:::note
+`Should.ErrorAction` defaults to `'Stop'`, so assertions are hard unless you opt in to `'Continue'`. See [`Should.ErrorAction`](../usage/configuration) in the configuration reference.
+:::
+
+### Example
+
+With soft assertions enabled you can validate several properties of an object in a single `It` and still get the full picture when more than one check fails:
+
+```powershell
+BeforeAll {
+    function Get-User {
+        @{
+            Name = "Jakub"
+            Age  = 31
+        }
+    }
+}
+
+Describe "Get-User" {
+    It "returns the expected user" {
+        $user = Get-User
+
+        $user      | Should -Not -BeNullOrEmpty -ErrorAction Stop
+        $user.Name | Should -Be "Tomas"
+        $user.Age  | Should -Be 27
+    }
+}
+```
+
+Both the `Name` and the `Age` assertions fail, and both are reported at the end of the test:
+
+```
+Running tests from 1 files.
+
+Running tests from 'C:\t\describe.Tests.ps1'
+Describing Get-User
+  [-] returns the expected user 124ms
+   [0] Expected strings to be the same, but they were different.
+   String lengths are both 5.
+   Strings differ at index 0.
+   Expected: 'Tomas'
+   But was:  'Jakub'
+              ^
+   at $user.Name | Should -Be "Tomas", C:\t\describe.Tests.ps1:15
+   [1] Expected 27, but got 31.
+   at $user.Age | Should -Be 27, C:\t\describe.Tests.ps1:16
+Tests completed in 286ms
+Tests Passed: 0, Failed: 1, Skipped: 0, Inconclusive: 0, NotRun: 0
+```
+
+The same works with the new `Should-*` assertions, because they honour `Should.ErrorAction` too:
+
+```powershell
+Describe "Get-User" {
+    It "returns the expected user" {
+        $user = Get-User
+
+        $user      | Should-NotBeNull -ErrorAction Stop
+        $user.Name | Should-Be "Tomas"
+        $user.Age  | Should-Be 27
+    }
+}
+```
+
+## Override the behavior on a single assertion
+
+`Should.ErrorAction` sets the default for the whole run, but you can override it on any individual assertion with the `-ErrorAction` parameter. This works for both `Should -Be` and `Should-*` assertions.
+
+- `-ErrorAction Stop` — make a single assertion hard even when soft assertions are enabled globally. Use it to guard a **precondition**: if that check fails, there is no point continuing, so fail the test immediately. In the example above, `Should -Not -BeNullOrEmpty -ErrorAction Stop` stops the test when `$user` is `$null`, because inspecting `.Name` and `.Age` on a null object would be meaningless.
+
+  ```powershell
+  # Soft assertions are on globally, but this precondition hard-fails the test.
+  $user | Should -Not -BeNullOrEmpty -ErrorAction Stop
+  ```
+
+- `-ErrorAction Continue` — make a single assertion soft even when the run defaults to hard assertions (`Should.ErrorAction = 'Stop'`). The failure is collected and the test keeps going.
+
+  ```powershell
+  # Default run (hard assertions), but collect this failure instead of stopping.
+  $user.Name | Should -Be "Tomas" -ErrorAction Continue
+  ```
+
+## Related
+
+- [`Should` assertions](./should-command) — the classic `Should -Be` and new `Should-*` syntaxes that soft assertions apply to.
+- [Configuration — `Should.ErrorAction`](../usage/configuration) — the full configuration reference.

--- a/sidebars.js
+++ b/sidebars.js
@@ -52,6 +52,7 @@ module.exports = {
     ],
     "Assertions": [
       "assertions/should-command",
+      "assertions/soft-assertions",
       "assertions/assertions",
       "assertions/custom-assertions",
     ],


### PR DESCRIPTION
## Summary

Addresses #385.

Pester v6's "soft assertion" behaviour (collect all failures instead of stopping at the first one) was under-documented and hard to discover — the word "soft assertion" did not appear anywhere on pester.dev, and the feature was only described at the bottom of the Should page under *"Collect all Should failures"*.

This PR adds a dedicated, searchable page for it.

### Changes

- **New page `docs/assertions/soft-assertions.mdx`** that:
  - Uses the term **"soft assertions"** explicitly (so site search finds it) and defines it: collect *all* assertion failures in a test instead of stopping at the first.
  - Explains how to enable them **globally for every assertion** via `Should.ErrorAction = 'Continue'`, using both `New-PesterConfiguration` and `$PesterPreference`.
  - States clearly that the global setting is honoured by **both** the classic `Should -Be` syntax and the new `Should-*` assertions, with a runnable example for each.
  - Shows how to override on a single assertion with `-ErrorAction Stop` (hard-fail a precondition before continuing) and `-ErrorAction Continue` (soft).
  - Cross-links to the Should page and the configuration reference.
- **`docs/assertions/should-command.mdx`**: consolidated the existing *"Collect all Should failures"* section into a short soft-reference that links to the new page (no more duplicated example), with a reciprocal link.
- **`sidebars.js`**: wired the new page into the **Assertions** section ordering.

The `Should.ErrorAction` property name, default (`'Stop'`) and behaviour were verified against the Pester v6 source (`src/csharp/Pester/ShouldConfiguration.cs`).

`yarn build` passes with no broken-link warnings.

### ⚠️ Scope note — Part 1 not included

Issue #385 has two parts. This PR implements **Part 2** only (the dedicated "Soft assertions" entry).

**Part 1** — surfacing the per-assertion `-ErrorAction` meaning on the generated `Should-*` Command Reference pages (e.g. `Should-Be`) — requires a **comment-based-help change in [pester/pester](https://github.com/pester/pester)**, because those pages are auto-generated from source. It cannot be done in this docs repo and is **not included here**. That is why this PR says *Addresses* rather than *Closes* #385.