### PR TITLE
docs: document hidden (dot-prefixed) files/folders discovery behavior (#321)

### DIFF
--- a/docs/migrations/v5-to-v6.mdx
+++ b/docs/migrations/v5-to-v6.mdx
@@ -60,6 +60,14 @@ The on-screen output changes too: a run prints one `Running tests from N files.`
 
 The per-file model also powers the experimental parallel runner (`Run.Parallel`). It keeps the same result object, with a few differences worth knowing - see [The Result Object](../usage/result-object#parallel-runner-edge-cases).
 
+### Hidden files and folders are now discovered
+
+In v5, discovery followed the PowerShell default and ignored hidden items, so files and folders whose names start with a dot on macOS/Linux (or carry the Hidden attribute on Windows) — such as `tests/.github` — were silently skipped by a recursive run. v6 discovers them by default; version-control directories (`.git`, `.svn` and `.hg`) are still skipped. See [File placement and naming](../usage/file-placement-and-naming#hidden-files-and-folders).
+
+**Symptom.** Test files that never ran under v5 — typically under a dot-prefixed folder like `tests/.github` — now run on v6 and can surface failures that were previously hidden.
+
+**Fix.** Usually none; this is the intended behavior, so fix or remove the newly discovered tests. To keep a path out of a run, exclude it with `Run.ExcludePath` (or `-ExcludePath`).
+
 ### Empty or `$null` `-ForEach` throws
 
 [Data-driven tests](../usage/data-driven-tests) now throw when `-ForEach` (or `-TestCases`) gets `$null` or an empty array, instead of silently skipping the block or test. This catches the common mistake of pointing `-ForEach` at a variable that wasn't defined in `BeforeDiscovery`, or external data that didn't load.

--- a/docs/usage/file-placement-and-naming.mdx
+++ b/docs/usage/file-placement-and-naming.mdx
@@ -21,6 +21,16 @@ src/public/Get-Emoji.ps1
 tests/public/Get-Emoji.Tests.ps1
 ```
 
+## Hidden files and folders
+
+On macOS and Linux a file or folder whose name starts with a dot — such as `.github` — is *hidden* (on Windows the equivalent is the *Hidden* file attribute). This matters when you mirror your source layout, because tests for code that lives in `.github` naturally end up in `tests/.github`.
+
+Pester v6 discovers test files inside hidden folders by default, so this mirrored layout works even for dotted paths — `tests/.github` is picked up automatically. Version-control directories (`.git`, `.svn` and `.hg`) are always skipped.
+
+:::note Pester v5 excludes hidden items
+In Pester v5 and earlier, discovery follows the PowerShell default and ignores hidden items, so a recursive run silently skips tests under a hidden folder like `tests/.github`. On v5, pass the folder as an explicit path (`Invoke-Pester -Path ./tests/.github`) to include the non-hidden files inside it; test files that are themselves hidden must still be named explicitly. This changed in v6 — see [Migrating from Pester v5 to v6](../migrations/v5-to-v6#hidden-files-and-folders-are-now-discovered).
+:::
+
 ## Custom conventions
 
 The convention above is the default that most projects use, but Pester is not prescriptive about how you should name or place your files. The default extension can be customized by setting the `Run.TestExtension` configuration option. The relative position of files can be then adjusted by changing the code you use to import files into tests. See [Importing tested functions](importing-tested-functions).

--- a/versioned_docs/version-v5/usage/file-placement-and-naming.mdx
+++ b/versioned_docs/version-v5/usage/file-placement-and-naming.mdx
@@ -21,6 +21,18 @@ src/public/Get-Emoji.ps1
 tests/public/Get-Emoji.Tests.ps1
 ```
 
+## Hidden files and folders
+
+On macOS and Linux a file or folder whose name starts with a dot — such as `.github` — is *hidden* (on Windows the equivalent is the *Hidden* file attribute). This matters when you mirror your source layout, because tests for code that lives in `.github` naturally end up in `tests/.github`.
+
+Pester follows the PowerShell default and ignores hidden items during discovery, so a recursive run over `tests` silently skips anything under a hidden folder like `tests/.github`.
+
+:::note Running tests inside a hidden folder
+Pass the hidden folder as an explicit path (`Invoke-Pester -Path ./tests/.github`) to include the non-hidden files inside it; test files that are themselves hidden must still be named explicitly.
+
+Pester v6 changes this default — it discovers hidden files and folders automatically, skipping only version-control directories (`.git`, `.svn` and `.hg`).
+:::
+
 ## Custom conventions
 
 The convention above is the default that most projects use, but Pester is not prescriptive about how you should name or place your files. The default extension can be customized by setting the `Run.TestExtension` configuration option. The relative position of files can be then adjusted by changing the code you use to code files into tests. See [Importing tested functions](importing-tested-functions).


### PR DESCRIPTION
## What & why

Documents how Pester test discovery treats **hidden files and folders** — dot-prefixed on macOS/Linux (e.g. `.github`), or carrying the *Hidden* attribute on Windows — using the `.github` → `tests/.github` scenario from the issue as the motivating example.

### Heads-up: the behavior differs by version

While writing this I verified the described behavior against the Pester source. The 2024 issue described hidden items being **excluded** (the PowerShell default), but that was fixed in the meantime:

- **v6** (`Find-File` uses `Get-ChildItem -Force` + manual walk, shipped in `6.0.0-rc1+` via pester/Pester#2693, "Fix #2515"): hidden files/folders **are discovered by default**; only `.git`/`.svn`/`.hg` are skipped.
- **v5** (`Find-File` without `-Force`): hidden items are **excluded** by default, so tests under `tests/.github` are silently skipped.

Because this docs site is versioned (`/docs/...` serves **v5** as `lastVersion`; the `/docs` folder is the **v6 preview**), documenting a single behavior would be wrong for one audience. So each version gets a note scoped to its actual behavior.

## Changes

- **`docs/usage/file-placement-and-naming.mdx`** (v6 preview): new **Hidden files and folders** section — hidden files/folders are discovered by default, VCS dirs skipped — with a note on the v5 difference and the explicit-path escape hatch.
- **`docs/migrations/v5-to-v6.mdx`** (v6 preview): matching, cross-linked migration entry *"Hidden files and folders are now discovered"* (Symptom/Fix), so upgraders learn previously-skipped tests now run.
- **`versioned_docs/version-v5/usage/file-placement-and-naming.mdx`** (v5 stable, the default `/docs/...`): new **Hidden files and folders** section documenting the exclusion + the explicit-path escape hatch (`Invoke-Pester -Path ./tests/.github`), noting v6 changes this.

Kept DRY: one authoritative note per version, cross-linked within v6. Claims are scoped to *default* discovery / the PowerShell hidden-item default and are not overstated.

## Validation

`yarn build` passes with no broken-link/anchor warnings; verified the new headings, anchors, and bidirectional cross-links render in the generated v5 and v6 pages.

Closes #321