### PR TITLE
docs: annotate examples that require non-default output level (#394)

### DIFF
--- a/docs/usage/setup-and-teardown.mdx
+++ b/docs/usage/setup-and-teardown.mdx
@@ -220,6 +220,7 @@ Describe "describe 1" {
 ```
 
 ```
+# Output level: Detailed
 Running tests from 1 files.
 Filter 'ExcludeTag' set to ('Acceptance').
 Filters selected 0 tests to run.

--- a/docs/usage/skip.mdx
+++ b/docs/usage/skip.mdx
@@ -38,6 +38,7 @@ Describe "describe1" {
 ```
 
 ```
+# Output level: Detailed
 Running tests from 1 files.
 
 Running tests from 'C:\t\Skip.Tests.ps1'
@@ -126,6 +127,7 @@ Invoke-Pester -Configuration $config
 Remaining tests are also skipped when a block's setup or teardown fails.
 
 ```
+# Output level: Detailed
   [+] first passes 33ms
   [-] second fails 12ms
   [!] third would pass 1ms

--- a/docs/usage/tags.mdx
+++ b/docs/usage/tags.mdx
@@ -53,6 +53,7 @@ Describe "Get-Beer" {
 ```
 
 ```
+# Output level: Detailed
 Running tests from 1 files.
 Filter 'Tag' set to ('Acceptance').
 Filter 'ExcludeTag' set to ('Flaky', 'Slow', 'LinuxOnly').
@@ -75,6 +76,7 @@ The tags are now also compared as `-like` wildcards, so you don't have to spell 
 Invoke-Pester $path -ExcludeTagFilter "Accept*", "*nuxonly" | Out-Null
 ```
 ```
+# Output level: Detailed
 Running tests from 1 files.
 Filter 'ExcludeTag' set to ('Accept*', '*nuxonly').
 Filters selected 1 tests to run.


### PR DESCRIPTION
## What

Adds a `# Output level: Detailed` comment to the docs examples whose displayed console output only appears at **Detailed** (or higher) verbosity, so readers copying an example and running it on the default **Normal** level aren't confused when their output doesn't match.

Spun out of fflaten's review on #386 ([discussion](https://github.com/pester/docs/pull/386#discussion_r3508461858)): filter lines, "running in file …", block headers and successful/skipped test lines are all Detailed+ output.

## Why these examples

I verified against a real Pester `6.0.0` run what each verbosity prints:

- **Normal (default):** `Running tests from N files.` banner, whole-file `[+]`/flattened `[-]` failures, and the summary line.
- **Detailed:** additionally `Filter '…' set to (…)`, `Filters selected N tests to run.`, per-file `Running tests from '<path>'`, `Describing`/`Context` headers, and every individual `[+]`/`[!]`/`[-]` test line.

I annotated **only** the examples where the shown output is *essential to the point* of the example **and** is invisible at the default level:

| File | Example | Why it needs Detailed |
| --- | --- | --- |
| `usage/tags.mdx` | `-TagFilter`/`-ExcludeTagFilter` run | `Filter …` lines + which tests were selected are Detailed-only (fflaten's exact case) |
| `usage/tags.mdx` | wildcard `-ExcludeTagFilter` run | same as above |
| `usage/setup-and-teardown.mdx` | `-ExcludeTag Acceptance` selecting 0 tests | the `Filter …` / `Filters selected 0 tests to run.` lines that explain *why* nothing ran are Detailed-only |
| `usage/skip.mdx` | "Skip on everything" | individual `[!]` skipped tests aren't printed at Normal (only the `Skipped:` count) |
| `usage/skip.mdx` | `Run.SkipRemainingOnFailure` | the per-test `[+]`/`[-]`/`[!]` tree showing which tests got skipped is Detailed-only |

The comment is placed at the top of each output block (directly above the Detailed-only output), matching where the reviewer anchored the suggestion and keeping the wording identical everywhere.

## Deliberately left unannotated (conservative, per "when essential for content")

- Examples that already show the level (`-Output Detailed` or `Output.Verbosity = 'Detailed'`), e.g. `quick-start.mdx`, `data-driven-tests.mdx` external-data demo, `skip.mdx` conditional-skip.
- Examples whose teaching point survives at the default level — Write-Host discovery/teardown **ordering** (`setup-and-teardown.mdx`, `data-driven-tests.mdx`), failing-test demos, and mock-debug logging (`configuration.mdx`) — only incidental block framing differs there.
- `assertions/custom-assertions.mdx` — its output is already the default flattened format, so no annotation is needed.
- Generated command pages (e.g. `commands/Set-ItResult.mdx`) — those are regenerated from comment-based help in `pester/Pester`; the fix belongs upstream.

## Validation

`yarn build` completes cleanly (no broken links/anchors, no MDX errors).

Closes #394