### PR TITLE
Remove Focus from result object property tables

### DIFF
--- a/docs/usage/result-object.mdx
+++ b/docs/usage/result-object.mdx
@@ -133,7 +133,7 @@ Type `Pester.Block`. Represents a `Describe` or `Context`. Blocks can nest, so a
 | Tests | `Test[]` | Tests directly inside this block. |
 | ErrorRecord | `object[]` | Errors from this block's setup/teardown (`BeforeAll`/`AfterAll`, etc.). |
 | Tag | `string[]` | Tags applied to the block. |
-| Skip / Focus | `bool` | Whether the block was skipped or focused. |
+| Skip | `bool` | Whether the block was skipped. |
 | TotalCount / PassedCount / FailedCount / SkippedCount / InconclusiveCount / NotRunCount | `int` | Counts for all tests under this block (including nested). |
 | Own&#42;Count | `int` | The same counts but only for tests directly in this block, excluding nested blocks. |
 | Duration / UserDuration / FrameworkDuration / DiscoveryDuration | `TimeSpan` | Timings for the block. |
@@ -158,7 +158,7 @@ Type `Pester.Test`. Represents a single `It`.
 | Data | `object` | The `-ForEach`/`-TestCases` data item bound to this test. |
 | Duration / UserDuration / FrameworkDuration | `TimeSpan` | Timings for the test. |
 | Tag | `string[]` | Tags applied to the test. |
-| Skip / Focus | `bool` | Whether the test was skipped or focused. |
+| Skip | `bool` | Whether the test was skipped. |
 | ShouldRun / Executed | `bool` | Whether the test was selected, and whether it actually ran. |
 | ExecutedAt | `DateTime?` | When the test ran (`$null` if it did not run). |
 | StartLine | `int` | Line where the test is declared. |


### PR DESCRIPTION
## What

Removes the `Focus` property from the **Block** and **Test** property tables on the [Result Object](https://pester.dev/docs/usage/result-object) page. The rows now document `Skip` only.

## Why

`Focus` is a vestigial leftover of the removed v5 `-Focus` feature. It is being removed from the Pester result object (`Block.Focus` / `Test.Focus`) in the companion PR **pester/Pester#2834**, so documenting it here is inaccurate going forward.

## Notes

- Docs-only change; two table rows updated in `docs/usage/result-object.mdx`.
- Companion change pester/Pester#2834 removes the property from the object model and notes it under *Breaking changes* in `docs/6.0.0.md`.