### PR TITLE
Revamp v6 assertions docs (Should-* output, hints, Should-BeEquivalent)

### DIFF
--- a/docs/assertions/assertions.mdx
+++ b/docs/assertions/assertions.mdx
@@ -6,8 +6,10 @@ description: Introduction to the built-in assertion operators in Pester to get y
 
 `Should` is a command that provides assertion convenience methods for comparing objects and throwing test failures when test expectations fail. `Should` is used inside `It` blocks of a Pester test script.
 
+This page is the reference for the **classic** `Should -Be` operators — the assertion style from Pester v4 and v5. They still ship and work in Pester v6, but for new tests we recommend the newer, type-aware [`Should-*` assertions](./should-command).
+
 :::tip New in Pester v6
-This page documents the classic `Should -Be` assertions, which still ship and work in Pester v6. Pester v6 also adds a set of specialized, type-aware [`Should-*` assertions](./should-command) (note the hyphen, no space) with clearer failure messages. Both styles work side by side, so you can adopt `Should-*` when it suits you and optionally turn off the classic syntax by setting `Should.DisableV5 = $true`.
+Pester v6 adds a set of specialized [`Should-*` assertions](./should-command) (note the hyphen, no space) with clearer failure messages, input-shape hints, and a dedicated [`Should-BeEquivalent`](./should-beequivalent) for deep object comparison. Both styles work side by side, so you can adopt `Should-*` when it suits you and optionally turn off the classic syntax by setting `Should.DisableV5 = $true`.
 :::
 
 ## Common parameters

--- a/docs/assertions/should-beequivalent.mdx
+++ b/docs/assertions/should-beequivalent.mdx
@@ -1,0 +1,304 @@
+---
+id: should-beequivalent
+title: Should-BeEquivalent
+description: Recursively compare objects, hashtables, PSCustomObjects, nested structures, and collections by value with Should-BeEquivalent, including -ExcludePath, -ExcludePathsNotOnExpected and -Comparator.
+---
+
+## Overview
+
+[`Should-BeEquivalent`](../commands/Should-BeEquivalent.mdx) recursively compares two objects — or collections of objects — **by value**. It walks every property, descends into nested objects and collections, and reports each place the two structures differ. It is the assertion to reach for when [`Should-Be`](../commands/Should-Be.mdx) (a single scalar) and [`Should-BeCollection`](../commands/Should-BeCollection.mdx) (a flat collection) are not enough.
+
+Key behaviors:
+
+- **Deep** — nested objects, hashtables, and collections are compared recursively, and the failure message tells you the exact path (`.Property`, `.Nested.City`) that differs.
+- **By value, not by reference** — two different objects with the same contents are equivalent.
+- **Order-insensitive for collections** — `@(1, 2, 3)` is equivalent to `@(3, 2, 1)`.
+
+When the two structures are not equivalent, the assertion throws a message with four parts: an `Expected:` dump, an `Actual:` dump, a `Summary:` that lists every difference by path, and — when you pass options — a `Used options:` footer.
+
+## Comparing hashtables
+
+```powershell
+@{ Name = 'Jakub'; Age = 31 } | Should-BeEquivalent @{ Name = 'Tomas'; Age = 31 }
+```
+
+```
+Expected and actual are not equivalent!
+Expected:
+@{Age=31; Name='Tomas'}
+
+Actual:
+@{Age=31; Name='Jakub'}
+
+Summary:
+Expected hashtable @{Age=31; Name='Tomas'}, but got @{Age=31; Name='Jakub'}.
+Expected property .Name with value 'Tomas' to be equivalent to the actual value, but got 'Jakub'.
+```
+
+The `Age` values match, so only `.Name` shows up in the summary. Key order does not matter — a hashtable with the same keys and values in a different order is equivalent:
+
+```powershell
+@{ Name = 'Jakub'; Age = 31 } | Should-BeEquivalent @{ Age = 31; Name = 'Jakub' }
+```
+
+This passes.
+
+## Comparing PSCustomObjects
+
+Objects are compared property by property, exactly like hashtables. The dump uses `PSObject{ ... }` so you can see the shape:
+
+```powershell
+$expected = [PSCustomObject]@{ Name = 'Tomas'; Age = 31 }
+[PSCustomObject]@{ Name = 'Jakub'; Age = 31 } | Should-BeEquivalent $expected
+```
+
+```
+Expected and actual are not equivalent!
+Expected:
+PSObject{
+    Age=31;
+    Name='Tomas';
+}
+
+Actual:
+PSObject{
+    Age=31;
+    Name='Jakub';
+}
+
+Summary:
+Expected property .Name with value 'Tomas' to be equivalent to the actual value, but got 'Jakub'.
+```
+
+### Nested objects
+
+Equivalency descends into nested objects, and the summary path grows to point at the exact leaf that differs — here `.Nested.City`:
+
+```powershell
+$expected = [PSCustomObject]@{ Name = 'Jakub'; Nested = [PSCustomObject]@{ City = 'Brno' } }
+$actual   = [PSCustomObject]@{ Name = 'Jakub'; Nested = [PSCustomObject]@{ City = 'Praha' } }
+
+$actual | Should-BeEquivalent $expected
+```
+
+```
+Expected and actual are not equivalent!
+Expected:
+PSObject{
+    Name='Jakub';
+    Nested=PSObject{
+        City='Brno';
+    };
+}
+
+Actual:
+PSObject{
+    Name='Jakub';
+    Nested=PSObject{
+        City='Praha';
+    };
+}
+
+Summary:
+Expected property .Nested.City with value 'Brno' to be equivalent to the actual value, but got 'Praha'.
+```
+
+When every nested value matches, the assertion passes:
+
+```powershell
+$expected = [PSCustomObject]@{ Name = 'Jakub'; Nested = [PSCustomObject]@{ City = 'Brno' } }
+$actual   = [PSCustomObject]@{ Name = 'Jakub'; Nested = [PSCustomObject]@{ City = 'Brno' } }
+
+$actual | Should-BeEquivalent $expected
+```
+
+## Comparing collections
+
+Collections are compared by value and are **order-insensitive**. A missing value is listed in the summary:
+
+```powershell
+1, 2, 3 | Should-BeEquivalent @(1, 2, 4)
+```
+
+```
+Expected and actual are not equivalent!
+Expected:
+@(1, 2, 4)
+
+Actual:
+@(1, 2, 3)
+
+Summary:
+Expected collection @(1, 2, 4) to be equivalent to @(1, 2, 3) but some values were missing: @(4).
+```
+
+Because order does not matter, the same values in a different order are equivalent:
+
+```powershell
+1, 2, 3 | Should-BeEquivalent @(3, 2, 1)
+```
+
+This passes.
+
+## Ignoring properties with `-ExcludePath`
+
+Real objects often carry volatile fields — a database `Id`, a `Timestamp`, a run-specific GUID — that you do not want to compare. Pass their paths to `-ExcludePath` (dot notation, e.g. `Nested.City`) to drop them from the comparison.
+
+Without the exclusion the volatile fields fail the comparison:
+
+```powershell
+$expected = [PSCustomObject]@{ Name = 'Jakub'; Id = 1; Timestamp = [datetime]'2024-01-01' }
+$actual   = [PSCustomObject]@{ Name = 'Jakub'; Id = 2; Timestamp = [datetime]'2025-06-30' }
+
+$actual | Should-BeEquivalent $expected
+```
+
+```
+Expected and actual are not equivalent!
+Expected:
+PSObject{
+    Id=1;
+    Name='Jakub';
+    Timestamp=01/01/2024 00:00:00;
+}
+
+Actual:
+PSObject{
+    Id=2;
+    Name='Jakub';
+    Timestamp=06/30/2025 00:00:00;
+}
+
+Summary:
+Expected property .Id with value 1 to be equivalent to the actual value, but got 2.
+Expected property .Timestamp with value 01/01/2024 00:00:00 to be equivalent to the actual value, but got 06/30/2025 00:00:00.
+```
+
+Exclude `Id` and `Timestamp` and the comparison passes, because only `Name` is left to compare:
+
+```powershell
+$actual | Should-BeEquivalent $expected -ExcludePath 'Id', 'Timestamp'
+```
+
+When excluding paths still leaves a real difference, the assertion fails and echoes the options it used in a `Used options:` footer, so it is clear what was and was not compared:
+
+```powershell
+$expected = [PSCustomObject]@{ Name = 'Tomas'; Id = 1 }
+$actual   = [PSCustomObject]@{ Name = 'Jakub'; Id = 2 }
+
+$actual | Should-BeEquivalent $expected -ExcludePath 'Id'
+```
+
+```
+Expected and actual are not equivalent!
+Expected:
+PSObject{
+    Id=1;
+    Name='Tomas';
+}
+
+Actual:
+PSObject{
+    Id=2;
+    Name='Jakub';
+}
+
+Summary:
+Expected property .Name with value 'Tomas' to be equivalent to the actual value, but got 'Jakub'.
+
+Used options:
+Exclude path 'Id'.
+```
+
+## Comparing a subset with `-ExcludePathsNotOnExpected`
+
+By default every property on **both** sides must match — an extra property on the actual object is a difference:
+
+```powershell
+$expected = [PSCustomObject]@{ Name = 'Jakub' }
+$actual   = [PSCustomObject]@{ Name = 'Jakub'; Age = 31; Email = 'jakub@example.com' }
+
+$actual | Should-BeEquivalent $expected
+```
+
+```
+Expected and actual are not equivalent!
+Expected:
+PSObject{
+    Name='Jakub';
+}
+
+Actual:
+PSObject{
+    Age=31;
+    Email='jakub@example.com';
+    Name='Jakub';
+}
+
+Summary:
+Expected is missing property 'Age' that the actual object has.
+Expected is missing property 'Email' that the actual object has.
+```
+
+Add `-ExcludePathsNotOnExpected` to compare **only** the properties present on `Expected` and ignore any extras on `Actual`. This is ideal for asserting that an object contains an expected subset:
+
+```powershell
+$actual | Should-BeEquivalent $expected -ExcludePathsNotOnExpected
+```
+
+This passes, because `Name` — the only property on `Expected` — matches.
+
+## Choosing the comparison strategy with `-Comparator`
+
+`-Comparator` controls how **leaf values** are compared. It does not change how objects, hashtables, or collections are walked — those are always recursive.
+
+- `Equivalency` (the default) — a lenient, value-based comparison. Among other things, scriptblocks are compared by their **text**, and the string `'False'` is treated as equivalent to the boolean `$false`.
+- `Equality` — a strict comparison of the leaf values.
+
+The difference is visible with a scriptblock property. Under the default `Equivalency`, two scriptblocks with the same body are equivalent:
+
+```powershell
+$expected = [PSCustomObject]@{ Name = 'Jakub'; Action = { Get-Process } }
+$actual   = [PSCustomObject]@{ Name = 'Jakub'; Action = { Get-Process } }
+
+$actual | Should-BeEquivalent $expected
+```
+
+This passes. With `-Comparator Equality` the two scriptblocks are compared strictly (by reference) and the assertion fails — notice the summary now says "to be **equal**" instead of "to be **equivalent**":
+
+```powershell
+$actual | Should-BeEquivalent $expected -Comparator Equality
+```
+
+```
+Expected and actual are not equivalent!
+Expected:
+PSObject{
+    Action={ Get-Process };
+    Name='Jakub';
+}
+
+Actual:
+PSObject{
+    Action={ Get-Process };
+    Name='Jakub';
+}
+
+Summary:
+Expected property .Action with value { Get-Process } to be equal to the actual value, but got { Get-Process }.
+```
+
+## When to prefer `Should-BeEquivalent`
+
+:::tip
+Reach for `Should-BeEquivalent` instead of [`Should-Be`](../commands/Should-Be.mdx) or [`Should-BeCollection`](../commands/Should-BeCollection.mdx) when:
+
+- you are comparing whole objects, hashtables, or `PSCustomObject`s rather than a single scalar,
+- the data is **nested** and you want a precise `.Path.To.Property` in the failure message,
+- collection **order** should not matter,
+- you want to ignore volatile fields with `-ExcludePath`, or assert on a subset with `-ExcludePathsNotOnExpected`.
+
+Use `Should-Be` for a single scalar value, and `Should-BeCollection` when you need an ordered, size-and-item comparison of a flat collection.
+:::
+
+See the [`Should-BeEquivalent` command reference](../commands/Should-BeEquivalent.mdx) for the full parameter list.

--- a/docs/assertions/should-command.mdx
+++ b/docs/assertions/should-command.mdx
@@ -1,17 +1,18 @@
 ---
+id: should-command
 title: Should
-description: Introduction to the Pester's built-in Should assertions which can be used to fail or pass a test
+description: The Should-* assertions introduced in Pester v6, how they render output, the input-shape hints, and the classic Should -Be syntax.
 ---
 
 ## Overview
 
 Pester includes a comprehensive set of assertions that you can use to either fail or pass a test.
-In fact, Pester v6 actually includes two sets of assertions:
+In fact, Pester v6 includes two sets of assertions:
 
-- All new `Should-*` assertions introduced in Pester v6, e.g. `Should-BeString`, `Should-BeTrue` etc.
-- The `Should` command known from previous version of Pester, invoked using parameter sets like `Should -Be`, `Should -BeTrue` etc.
+- The new `Should-*` assertions introduced in Pester v6 (note the hyphen, no space), e.g. `Should-Be`, `Should-BeString`, `Should-BeTrue`. **These are the recommended way to assert in v6** and are the focus of this page.
+- The classic `Should` command known from previous versions of Pester, invoked using parameter sets like `Should -Be`, `Should -BeTrue`. This is the older syntax and is documented separately in the [Assertion Reference (v4/v5)](./assertions.mdx).
 
-Both types of assertions are supported side-by-side in Pester v6, but we recommend you try out and migrate to the newer assertions.
+Both styles are supported side-by-side in Pester v6, so you can migrate one test at a time. We recommend you try out and move to the newer `Should-*` assertions.
 
 ## `Should-*` assertions (v6)
 
@@ -88,6 +89,10 @@ Should-Be -Actual 1 -Expected 1
 Should-Be -Actual @(1) -Expected 1
 ```
 
+:::tip
+The pipeline is convenient, but it reshapes your input. When the exact shape matters — a single-item collection, an empty collection, `$null`, or a dictionary — prefer `-Actual`, which preserves the value exactly. See [Input-shape hints](#input-shape-hints) for the failures this causes and the hints Pester prints to help.
+:::
+
 ### Value assertions
 
 #### Generic value assertions
@@ -107,6 +112,26 @@ The assertions in the above examples will both pass:
 - `1` converts to `bool`-value as `$true`, which is the expected value.
 - `Get-Process` retrieves the `Idle` process (on Windows). This process object gets converted to `string` which is equal to the expected value.
 
+When an assertion fails it throws, and the message shows the expected and the actual value:
+
+```powershell
+2 | Should-Be 1
+```
+
+```
+Expected [int] 1, but got [int] 2.
+```
+
+Use `-Because` to append the reason the test should pass; it is woven into the message:
+
+```powershell
+2 | Should-Be 1 -Because 'the config default must be 1'
+```
+
+```
+Expected [int] 1, because the config default must be 1, but got [int] 2.
+```
+
 #### Type specific value assertions
 
 Type specific assertions are for asserting on a single value of a given type like `boolean`.
@@ -114,6 +139,54 @@ These assertions take the advantage of being more specialized to provide a type 
 
 - `$Expected` accepts input that has the same type as the assertion type. E.g. `Should-BeString -Expected "my string"`.
 - `$Actual` accepts input that has the same type as the assertion type. The input is **not** converted to the destination type unless the assertion specifies it, e.g. `Should-BeFalsy` will convert to `bool`.
+
+For example, [`Should-BeTrue`](../commands/Should-BeTrue.mdx) asserts on a boolean:
+
+```powershell
+$true | Should-BeTrue   # passes
+$false | Should-BeTrue  # fails
+```
+
+```
+Expected [bool] $true, but got: [bool] $false.
+```
+
+[`Should-BeString`](../commands/Should-BeString.mdx) compares strings and points at the first character that differs:
+
+```powershell
+'Jakub' | Should-BeString 'Tomas'
+```
+
+```
+Expected strings to be the same, but they were different.
+String lengths are both 5.
+Strings differ at index 0.
+Expected: 'Tomas'
+But was:  'Jakub'
+          ^
+```
+
+[`Should-HaveType`](../commands/Should-HaveType.mdx) asserts on the type of a value:
+
+```powershell
+'hello' | Should-HaveType ([string])   # passes
+1 | Should-HaveType ([string])         # fails
+```
+
+```
+Expected value to have type [string], but got [int] 1.
+```
+
+[`Should-BeGreaterThan`](../commands/Should-BeGreaterThan.mdx) is a comparison assertion and reports the actual value that failed the comparison:
+
+```powershell
+10 | Should-BeGreaterThan 5   # passes
+1 | Should-BeGreaterThan 5    # fails
+```
+
+```
+Expected the actual value to be greater than [int] 5, but it was not. Actual: [int] 1
+```
 
 ### Collection assertions
 
@@ -127,8 +200,14 @@ Collection assertions operate on the whole collection provided to `$Actual` inst
 1, 2, 3 | Should-BeCollection @(1, 2, 3)
 @(1)    | Should-BeCollection @(1)
 
-# This fails, the collections have different sizes.
-1, 2, 3, 4 | Should-BeCollection @(1, 2, 3)
+# This fails, one item differs.
+1, 2, 3 | Should-BeCollection @(1, 2, 4)
+```
+
+```
+Expected [Object[]] @(1, 2, 4) to be present in [Object[]] @(1, 2, 3) in any order, but some values were not.
+Missing in actual: '4 (index 2)'
+Extra in actual: '3 (index 2)'
 ```
 
 You can also assert on the size of a collection without comparing items, by using `-Count`:
@@ -151,16 +230,191 @@ Combinator assertions take a `-FilterScript` and run it against every item in th
 [`Should-All`](../commands/Should-All.mdx) passes when **every** item matches the filter:
 
 ```powershell
-1, 2, 3 | Should-All { $_ -gt 0 }
+1, 2, 3 | Should-All { $_ -gt 0 }        # passes
 1, 2, 3 | Should-All { $_ | Should-BeGreaterThan 0 }
+
+1, 2, 3 | Should-All { $_ -gt 1 }        # fails
+```
+
+```
+Expected all items in collection @(1, 2, 3) to pass filter { $_ -gt 1 }, but 1 of them 1 did not pass the filter.
 ```
 
 [`Should-Any`](../commands/Should-Any.mdx) passes when **at least one** item matches the filter:
 
 ```powershell
-1, 2, 3 | Should-Any { $_ -gt 2 }
+1, 2, 3 | Should-Any { $_ -gt 2 }        # passes
 1, 2, 3 | Should-Any { $_ | Should-BeGreaterThan 2 }
+
+1, 2, 3 | Should-Any { $_ -gt 5 }        # fails
 ```
+
+```
+Expected at least one item in collection @(1, 2, 3) to pass filter { $_ -gt 5 }, but none of the items passed the filter.
+```
+
+### Deep object comparison
+
+To compare whole objects, hashtables, or nested structures **by value** — instead of a single scalar or a flat collection — use [`Should-BeEquivalent`](../commands/Should-BeEquivalent.mdx). It walks properties and nested objects recursively and is order-insensitive for collections.
+
+```powershell
+@{ Name = 'Jakub'; Age = 31 } | Should-BeEquivalent @{ Name = 'Tomas'; Age = 31 }
+```
+
+```
+Expected and actual are not equivalent!
+Expected:
+@{Age=31; Name='Tomas'}
+
+Actual:
+@{Age=31; Name='Jakub'}
+
+Summary:
+Expected hashtable @{Age=31; Name='Tomas'}, but got @{Age=31; Name='Jakub'}.
+Expected property .Name with value 'Tomas' to be equivalent to the actual value, but got 'Jakub'.
+```
+
+See the dedicated [Should-BeEquivalent](./should-beequivalent) page for a deep dive: PSCustomObjects, nested objects, collections, and the `-ExcludePath`, `-ExcludePathsNotOnExpected`, and `-Comparator` options.
+
+### Input-shape hints
+
+The `Should-*` assertions accept their input through the pipeline (`| Should-…`) or the `-Actual` parameter. The pipeline is convenient, but PowerShell **reshapes** whatever is on the left side before the assertion ever sees it:
+
+- a **one-item collection** is unwrapped to its single element,
+- a **multi-item collection** is streamed and re-collected as a fresh `[object[]]` (its original type is lost),
+- a **dictionary/hashtable** is passed through as one object and is **never** enumerated,
+- `$null` stays `$null` and an empty collection `@()` sends nothing at all.
+
+Passing the value with `-Actual` instead preserves it exactly.
+
+When an assertion **fails** and Pester detects that the input was very likely the wrong shape, it appends an extra line that starts with `Hint:` to the failure message. The hint **never** changes whether an assertion passes or fails — it only appears on a failure, to explain the gotcha and how to fix it.
+
+:::note
+Hints are best-effort diagnostics shown only on failure. A passing assertion never prints a hint, and an ordinary mismatch (for example a plain scalar that simply is not equal) does not print one either.
+:::
+
+#### Collection assertions — scalar, `$null`, or a dictionary
+
+[`Should-BeCollection`](../commands/Should-BeCollection.mdx) compares the whole input as one collection. Piping a lone scalar, `$null`, or a dictionary is almost never what you meant, so all three get a hint.
+
+A scalar:
+
+```powershell
+5 | Should-BeCollection @(1)
+```
+
+```
+Expected [Object[]] @(1) to be present in [Object[]] @(5) in any order, but some values were not.
+Missing in actual: '1 (index 0)'
+Extra in actual: '5 (index 0)'
+
+Hint: You piped a single [int] into a collection assertion. It is treated as a single item. To assert on a one-item collection wrap it as ,$actual, or use Should-Be for a scalar value.
+```
+
+`$null` (treated as a single `$null` item, not an empty collection):
+
+```powershell
+$null | Should-BeCollection @(1)
+```
+
+```
+Expected [Object[]] @(1) to be present in [Object[]] @($null) in any order, but some values were not.
+Missing in actual: '1 (index 0)'
+Extra in actual: '$null (index 0)'
+
+Hint: You piped $null into a collection assertion. It is treated as a single $null item, not an empty collection. Use @() to represent an empty collection.
+```
+
+A dictionary/hashtable (passed through as one object):
+
+```powershell
+@{ Name = 'Jakub'; Age = 31 } | Should-BeCollection @(1)
+```
+
+```
+Expected [Object[]] @(1) to be present in [Object[]] @(@{Age=31; Name='Jakub'}) in any order, but some values were not.
+Missing in actual: '1 (index 0)'
+Extra in actual: '@{Age=31; Name='Jakub'} (index 0)'
+
+Hint: You piped a single [hashtable] into a collection assertion. PowerShell treats a dictionary as a single object, not a collection. To assert on it as a hashtable use Should-BeHashtable, or compare its contents with Should-BeEquivalent.
+```
+
+The same wrong shapes get a hint through `-Actual` too, with slightly different wording because nothing was piped:
+
+```powershell
+Should-BeCollection -Actual @{ Name = 'Jakub'; Age = 31 } -Expected @(1)
+```
+
+```
+Actual [hashtable] @{Age=31; Name='Jakub'} is not a collection.
+
+Hint: -Actual is a single [hashtable], which is not a collection. PowerShell treats a dictionary as a single object, not a collection. To assert on it as a hashtable use Should-BeHashtable, or compare its contents with Should-BeEquivalent.
+```
+
+#### Item-wise collection assertions — a dictionary
+
+[`Should-All`](../commands/Should-All.mdx), [`Should-Any`](../commands/Should-Any.mdx), [`Should-ContainCollection`](../commands/Should-ContainCollection.mdx) and [`Should-NotContainCollection`](../commands/Should-NotContainCollection.mdx) iterate or search the input **item by item**. A lone scalar or `$null` is a perfectly valid one-item collection here, so they are not flagged. A dictionary is the genuine gotcha — PowerShell passes it through as a single object instead of enumerating it:
+
+```powershell
+@{ Name = 'Jakub'; Age = 31 } | Should-All { $_ -gt 0 }
+```
+
+```
+Expected all items in collection @(@{Age=31; Name='Jakub'}) to pass filter { $_ -gt 0 }, but 1 of them @{Age=31; Name='Jakub'} did not pass the filter.
+Reasons :
+Cannot compare "System.Collections.Hashtable" because it is not IComparable.
+
+Hint: You piped a single [hashtable] into a collection assertion. PowerShell treats a dictionary as a single object, so it is passed through as one item instead of being iterated. Enumerate it first, e.g. with $actual.GetEnumerator(), or its .Keys or .Values, or assert on it directly with Should-BeHashtable.
+```
+
+#### Type assertions — a piped collection
+
+[`Should-HaveType`](../commands/Should-HaveType.mdx) and [`Should-NotHaveType`](../commands/Should-NotHaveType.mdx) check a **single** value against a type. Piping a collection unwraps it, so the type you meant to check is lost before the assertion runs. A single-item collection collapses to its one element:
+
+```powershell
+[string[]]('a') | Should-HaveType ([string[]])
+```
+
+```
+Expected value to have type [string[]], but got [string] 'a'.
+
+Hint: You piped a [string[]] into a type assertion, but the pipeline unwraps a single-item collection to its one element, so the assertion saw a single [string], not the [string[]] you piped. To assert the type of a collection, pass it as the -Actual argument instead of piping it, e.g. -Actual $value.
+```
+
+A multi-item collection is streamed and re-collected as `[object[]]`:
+
+```powershell
+[string[]]('a', 'b') | Should-HaveType ([string[]])
+```
+
+```
+Expected value to have type [string[]], but got [Object[]] @('a', 'b').
+
+Hint: You piped a [string[]] into a type assertion, but the pipeline streams a multi-item collection and re-collects it as [Object[]], so the assertion saw [Object[]], not the [string[]] you piped. To assert the type of a collection, pass it as the -Actual argument instead of piping it, e.g. -Actual $value.
+```
+
+As the hint says, pass the collection with `-Actual` to keep its real type — `Should-HaveType -Actual ([string[]]('a', 'b')) -Expected ([string[]])` passes.
+
+#### Single-value assertions — a piped collection
+
+[`Should-Be`](../commands/Should-Be.mdx) and the other single-value assertions (the comparison, boolean, string, `$null`, and time assertions) inspect **one** value. Piping a collection collapses it into a single value, so the assertion silently compares the collapsed value instead of the collection:
+
+```powershell
+1, 2, 3 | Should-Be 1
+```
+
+```
+Expected [int] 1, but got [Object[]] @(1, 2, 3).
+
+Hint: You piped a [Object[]] into a single-value assertion, but the pipeline streams a multi-item collection and re-collects it into a single [Object[]], so the whole collection was inspected as one value. To assert on a collection use Should-BeCollection or Should-BeEquivalent; to assert on a single value pass it as the -Actual argument instead of piping it, e.g. -Actual $value.
+```
+
+#### Pipeline vs. `-Actual`
+
+The hints all point at the same root cause: **the pipeline reshapes your input, `-Actual` does not.**
+
+- Pipe a value when you want the convenient, unwrapped behavior and the shape does not matter.
+- Use `-Actual` (or the assertion the hint suggests — `Should-BeCollection`, `Should-BeEquivalent`, `Should-BeHashtable`) when the exact shape matters: a collection whose type you care about, a one-item collection, an empty collection, `$null`, or a dictionary.
 
 ### Assertion reference
 
@@ -208,9 +462,13 @@ All `Should-*` assertions are listed below, grouped by the kind of check they pe
 - [`Should-All`](../commands/Should-All.mdx) — Asserts that every item in the collection matches a filter.
 - [`Should-Any`](../commands/Should-Any.mdx) — Asserts that at least one item in the collection matches a filter.
 
+#### Hashtable
+
+- [`Should-BeHashtable`](../commands/Should-BeHashtable.mdx) — Compares a dictionary/hashtable against expected keys and values.
+
 #### Equivalency
 
-- [`Should-BeEquivalent`](../commands/Should-BeEquivalent.mdx) — Recursively compares two objects for equivalency, by comparing their properties.
+- [`Should-BeEquivalent`](../commands/Should-BeEquivalent.mdx) — Recursively compares two objects for equivalency, by comparing their properties. See the dedicated [Should-BeEquivalent](./should-beequivalent) page for a walkthrough with rendered output.
 
 #### DateTime and TimeSpan
 
@@ -252,9 +510,7 @@ Pester Should -Be syntax is disabled. Use Should-Be (without space), or enable i
 
 ## `Should` (v4/v5)
 
-`Should` is used to do an assertion that fails or passes the test.
-
-An example of assertion is comparing two strings in case insensitive manner:
+`Should` is the classic assertion syntax from Pester v4 and v5. It is still fully supported in v6 and uses parameter sets like `Should -Be`, `Should -Match`, or `Should -Throw`:
 
 ```powershell
 "Pester is bad." | Should -Be "Pester is awesome!"
@@ -272,8 +528,7 @@ But was:  'Pester is bad.'
            ----------^
 ```
 
-Other assertion types can be found in [Assertion Reference](.).
-
+This is the older style. The full list of operators (`-Be`, `-BeExactly`, `-BeGreaterThan`, `-Match`, `-Throw`, `-HaveParameter`, and the rest) lives on the dedicated [Assertion Reference (v4/v5)](./assertions.mdx) page. For new tests, prefer the [`Should-*` assertions](#should--assertions-v6) above.
 
 ### Collect all Should failures
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -52,6 +52,7 @@ module.exports = {
     ],
     "Assertions": [
       "assertions/should-command",
+      "assertions/should-beequivalent",
       "assertions/soft-assertions",
       "assertions/assertions",
       "assertions/custom-assertions",


### PR DESCRIPTION
## Summary

Revamps the **Assertions** documentation group so the Pester v6 `Should-*` assertions are the primary, first-class content and the classic v4/v5 `Should -Be` syntax is a clearly-separate secondary reference (v6 first, v5 after).

## What changed

**`assertions/should-command.mdx` (v6 primary)**
- Reframed the overview so `Should-*` leads and the classic `Should` is presented as the older syntax.
- Kept all the existing semantics content (value-vs-collection, pipeline-vs-`-Actual`, the categorized `Should-*` reference, `Should.DisableV5`, and the soft-assertions teaser).
- **Added real rendered output** (a passing call and a failing call with the real message) to the generic value, boolean, string, type, collection, and combinator examples.
- **New "Input-shape hints" section** documenting the `Hint:` diagnostics Pester appends to a *failing* assertion when it detects the wrong input shape. Covers all four cases:
  - collection assertions (`Should-BeCollection`) → scalar, `$null`, dictionary,
  - item-wise collection assertions (`Should-All/Any/ContainCollection/NotContainCollection`) → dictionary,
  - type assertions (`Should-HaveType/NotHaveType`) → piped collection,
  - single-value assertions (`Should-Be`, string/boolean/comparison/null/time) → piped collection,
  - plus the pipeline-vs-`-Actual` nuance (piping unwraps/re-collects; `-Actual` preserves the value).
- Trimmed the bottom v4/v5 material to link to the dedicated reference instead of duplicating it, and added a `Should-BeEquivalent` teaser.

**`assertions/should-beequivalent.mdx` (new dedicated page)**
- Deep object comparison walkthrough with runnable examples and real output: hashtables, PSCustomObjects, **nested** objects (`.Nested.City` paths), collections (order-insensitive), passing cases, and the `-ExcludePath`, `-ExcludePathsNotOnExpected`, and `-Comparator` (Equivalency vs Equality) options — including the `Used options:` footer. Ends with a `:::tip` on when to prefer it over `Should-Be` / `Should-BeCollection`.

**`assertions/assertions.mdx`**
- Light reframing so it reads as the older/secondary v4/v5 operator reference.

**`sidebars.js`**
- Added `assertions/should-beequivalent` right after `assertions/should-command`, keeping v6 first.

## Verification
- **Every example output was generated from real Pester 6.0.0 (`main`) runs** — nothing is invented. Failures were captured via `try { … } catch { $_.Exception.Message }`.
- Clean Docusaurus build (`yarn install && yarn build`) passes with **no broken links** and no MDX errors. All cross-links to `../commands/Should-*.mdx` resolve.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>