### PR TITLE
Clarify assertion sidebar/page titles (v6 vs v5)

### DIFF
--- a/docs/assertions/assertions.mdx
+++ b/docs/assertions/assertions.mdx
@@ -1,12 +1,12 @@
 ---
 id: assertions
-title: Assertion Reference (v4/v5)
+title: Classic assertions (v5)
 description: Introduction to the built-in assertion operators in Pester to get you started with the most common scenarios
 ---
 
 `Should` is a command that provides assertion convenience methods for comparing objects and throwing test failures when test expectations fail. `Should` is used inside `It` blocks of a Pester test script.
 
-This page is the reference for the **classic** `Should -Be` operators — the assertion style from Pester v4 and v5. They still ship and work in Pester v6, but for new tests we recommend the newer, type-aware [`Should-*` assertions](./should-command).
+This page is the reference for the **classic** `Should -Be` operators — the assertion style from Pester v5. They still ship and work in Pester v6, but for new tests we recommend the newer, type-aware [`Should-*` assertions](./should-command).
 
 :::tip New in Pester v6
 Pester v6 adds a set of specialized [`Should-*` assertions](./should-command) (note the hyphen, no space) with clearer failure messages, input-shape hints, and a dedicated [`Should-BeEquivalent`](./should-beequivalent) for deep object comparison. Both styles work side by side, so you can adopt `Should-*` when it suits you and optionally turn off the classic syntax by setting `Should.DisableV5 = $true`.
@@ -38,7 +38,7 @@ $mPlanets.Name + @('Earth') | Should -Be 'Mercury','Mars' -Because 'those are th
 
 You can find a list of all operators included in Pester below. You may also use [Get-ShouldOperator](../commands/Get-ShouldOperator) to list the available operators, their aliases and help inside PowerShell.
 
-You may also create custom operators to support more complex assertions, see [Custom Assertions](./custom-assertions).
+You may also create custom operators to support more complex assertions, see [Custom assertions](./custom-assertions).
 
 ### Be
 

--- a/docs/assertions/custom-assertions.mdx
+++ b/docs/assertions/custom-assertions.mdx
@@ -1,5 +1,5 @@
 ---
-title: Custom Assertions
+title: Custom assertions (v5)
 description: A guide for creating your own custom operators for more advanced or user-specific assertion needs
 ---
 

--- a/docs/assertions/should-command.mdx
+++ b/docs/assertions/should-command.mdx
@@ -1,6 +1,6 @@
 ---
 id: should-command
-title: Should
+title: "Should-* assertions (v6)"
 description: The Should-* assertions introduced in Pester v6, how they render output, the input-shape hints, and the classic Should -Be syntax.
 ---
 
@@ -10,11 +10,11 @@ Pester includes a comprehensive set of assertions that you can use to either fai
 In fact, Pester v6 includes two sets of assertions:
 
 - The new `Should-*` assertions introduced in Pester v6 (note the hyphen, no space), e.g. `Should-Be`, `Should-BeString`, `Should-BeTrue`. **These are the recommended way to assert in v6** and are the focus of this page.
-- The classic `Should` command known from previous versions of Pester, invoked using parameter sets like `Should -Be`, `Should -BeTrue`. This is the older syntax and is documented separately in the [Assertion Reference (v4/v5)](./assertions.mdx).
+- The classic `Should` command known from previous versions of Pester, invoked using parameter sets like `Should -Be`, `Should -BeTrue`. This is the older syntax and is documented separately in the [Classic assertions (v5)](./assertions.mdx).
 
 Both styles are supported side-by-side in Pester v6, so you can migrate one test at a time. We recommend you try out and move to the newer `Should-*` assertions.
 
-## `Should-*` assertions (v6)
+## The `Should-*` assertions
 
 Pester v6 comes with a new set of `Should-*` assertions that have been built from the ground up.
 If you've previously tested the [`Assert`](https://github.com/nohwnd/assert)-module, these will be familiar.
@@ -508,9 +508,9 @@ With `Should.DisableV5` enabled, using the classic `Should -Be` syntax throws, p
 Pester Should -Be syntax is disabled. Use Should-Be (without space), or enable it by setting: $PesterPreference.Should.DisableV5 = $false
 ```
 
-## `Should` (v4/v5)
+## `Should` (v5)
 
-`Should` is the classic assertion syntax from Pester v4 and v5. It is still fully supported in v6 and uses parameter sets like `Should -Be`, `Should -Match`, or `Should -Throw`:
+`Should` is the classic assertion syntax from Pester v5. It is still fully supported in v6 and uses parameter sets like `Should -Be`, `Should -Match`, or `Should -Throw`:
 
 ```powershell
 "Pester is bad." | Should -Be "Pester is awesome!"
@@ -528,7 +528,7 @@ But was:  'Pester is bad.'
            ----------^
 ```
 
-This is the older style. The full list of operators (`-Be`, `-BeExactly`, `-BeGreaterThan`, `-Match`, `-Throw`, `-HaveParameter`, and the rest) lives on the dedicated [Assertion Reference (v4/v5)](./assertions.mdx) page. For new tests, prefer the [`Should-*` assertions](#should--assertions-v6) above.
+This is the older style. The full list of operators (`-Be`, `-BeExactly`, `-BeGreaterThan`, `-Match`, `-Throw`, `-HaveParameter`, and the rest) lives on the dedicated [Classic assertions (v5)](./assertions.mdx) page. For new tests, prefer the [`Should-*` assertions](#the-should--assertions) above.
 
 ### Collect all Should failures
 


### PR DESCRIPTION
Follow-up to #401 (now merged). Tightens the **Assertions** sidebar/page titles so the v6-vs-classic split is obvious at a glance, and refers to the classic syntax as **v5** (dropping v4).

## Changes

- **`should-command`** title `Should` → **`Should-* assertions (v6)`**. Renamed the internal wrapper heading `## Should-* assertions (v6)` → `## The Should-* assertions` so it no longer duplicates the page's H1, and updated its one in-page anchor link. The trailing classic section is now `## Should (v5)`.
- **`assertions`** title `Assertion Reference (v4/v5)` → **`Classic assertions (v5)`**.
- **`custom-assertions`** title `Custom Assertions` → **`Custom assertions (v5)`**.
- Updated in-page link texts to match the new page names and the `v5` label.

Resulting sidebar order (unchanged — the classic/custom pages already sort last, after the three v6 pages):

- Should-\* assertions (v6)
- Should-BeEquivalent
- Soft assertions
- Classic assertions (v5)
- Custom assertions (v5)

## Verification

Clean Docusaurus build (`yarn build`) — no broken links or anchors.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>