### PR TITLE
Document the reserved 'None' tag filter

### DIFF
--- a/docs/migrations/v5-to-v6.mdx
+++ b/docs/migrations/v5-to-v6.mdx
@@ -274,6 +274,14 @@ $config.CodeCoverage.Path = './src'
 Invoke-Pester -Configuration $config
 ```
 
+### `None` is now a reserved tag-filter value
+
+`None` (case-insensitive) is now a special value for `-TagFilter` / `Filter.Tag` and `-ExcludeTagFilter` / `Filter.ExcludeTag` that means "tests that have no tags" — no tag on the test itself or on any of its parent blocks. Previously `None` was an ordinary string that only matched a literal tag named `None`.
+
+**Symptom.** If you used `None` as a real tag, `-TagFilter "None"` now also selects every untagged test, and `-ExcludeTagFilter "None"` now also skips every untagged test, instead of matching only the tests you tagged `None`.
+
+**Fix.** Rename the tag to something other than `None` if you relied on the old literal match. A test that is still literally tagged `None` keeps being selected — or, with the exclude filter, skipped — together with the untagged tests, so nothing falls through silently. See [Tags](../usage/tags#run-tests-that-have-no-tags).
+
 ## New in v6 (optional)
 
 None of these are required to upgrade — your v5 suite keeps working without them. They are the main things v6 adds that you may want to adopt once your suite is green.

--- a/docs/usage/configuration.mdx
+++ b/docs/usage/configuration.mdx
@@ -160,8 +160,8 @@ Filter options to include/exclude tests and blocks in the targeted containers us
 <div className="table-wrapper">
 | Option | Description | Type | Default |
 |--------|-------------|-----:|--------:|
-| Filter.Tag | Tags of Describe, Context or It to be run. | `string[]` | `@()` |
-| Filter.ExcludeTag | Tags of Describe, Context or It to be excluded from the run. | `string[]` | `@()` |
+| Filter.Tag | Tags of Describe, Context or It to be run. Use 'None' to run only tests that have no tags. | `string[]` | `@()` |
+| Filter.ExcludeTag | Tags of Describe, Context or It to be excluded from the run. Use 'None' to exclude tests that have no tags. | `string[]` | `@()` |
 | Filter.Line | Filter by file and scriptblock start line, useful to run parsed tests programmatically to avoid problems with expanded names. Explicit filter that overrides -Skip. Example: 'C:\tests\file1.Tests.ps1:37' | `string[]` | `@()` |
 | Filter.ExcludeLine | Exclude by file and scriptblock start line, takes precedence over Line. | `string[]` | `@()` |
 | Filter.FullName | Full name of test with -like wildcards, joined by dot. Example: '*.describe Get-Item.test1' | `string[]` | `@()` |

--- a/docs/usage/tags.mdx
+++ b/docs/usage/tags.mdx
@@ -88,3 +88,32 @@ Describing Get-Beer
 Tests completed in 269ms
 Tests Passed: 1, Failed: 0, Skipped: 0, Inconclusive: 0, NotRun: 6
 ```
+
+#### Run tests that have no tags
+
+Use the reserved tag `None` to select the tests that have **no tags at all**. `-TagFilter "None"` runs only the tests that have no tag on themselves or on any of their parent blocks, and `-ExcludeTagFilter "None"` does the opposite and skips them, so you run only the tagged tests. `None` is matched case-insensitively.
+
+Because tags are inherited, a test without its own tag that sits inside a tagged `Describe` or `Context` counts as tagged and is **not** selected by `None`. In the suite above, `acceptance test 2` has no tag of its own, but it lives in a `Context` tagged `Acceptance`, so `-TagFilter "None"` skips it and runs only the genuinely untagged `unit test 1`:
+
+```powershell
+Invoke-Pester $path -TagFilter "None" | Out-Null
+```
+```
+# Output level: Detailed
+Running tests from 1 files.
+Filter 'Tag' set to ('None').
+Filters selected 1 tests to run.
+
+Running tests from '...\real-life-tagging-scenarios.tests.ps1'
+Describing Get-Beer
+ Context unit tests
+   [+] unit test 1 15ms
+Tests completed in 269ms
+Tests Passed: 1, Failed: 0, Skipped: 0, Inconclusive: 0, NotRun: 6
+```
+
+You can combine `None` with real tags, for example `-TagFilter "None", "Acceptance"` runs the untagged tests **and** the acceptance tests.
+
+:::note Reserved since Pester 6
+`None` is a reserved filter value starting in Pester 6. If you use `None` as a real tag, filtering by it now also selects &mdash; or, with `-ExcludeTagFilter`, skips &mdash; every untagged test. A test that is literally tagged `None` is still matched by the filter, so it is included (or excluded) together with the untagged tests.
+:::


### PR DESCRIPTION
## What

Documents the new **`None` tag filter** introduced in Pester 6 (implemented in pester/Pester#2836).

`None` (case-insensitive) is now a reserved value for `-TagFilter` / `Filter.Tag` and `-ExcludeTagFilter` / `Filter.ExcludeTag` that means *"tests that have no tags"* — no tag on the test itself or on any of its parent blocks (tags inherit downward). A test that is literally tagged `None` is still matched, so it is included (or, with the exclude filter, skipped) together with the untagged tests.

## Changes

- **`docs/usage/tags.mdx`** — new *"Run tests that have no tags"* section with a worked example (`-TagFilter "None"`) and a "Reserved since Pester 6" note.
- **`docs/usage/configuration.mdx`** — the `Filter.Tag` / `Filter.ExcludeTag` rows now mention the `None` value (mirrors the option descriptions in `FilterConfiguration.cs`).
- **`docs/migrations/v5-to-v6.mdx`** — new breaking-change entry: `None` is now a reserved tag-filter value, with symptom/fix guidance.

## Related

- Code, tests, and release notes: pester/Pester#2836

> [!NOTE]
> The `configuration.mdx` rows were edited to match what `generate-pesterconfiguration-docs.ps1` produces from the updated `FilterConfiguration.cs`, so they stay in sync on the next regeneration.