### PR TITLE
Finalize v6 as the latest docs version

### DIFF
--- a/docs/migrations/v5-to-v6.mdx
+++ b/docs/migrations/v5-to-v6.mdx
@@ -24,8 +24,8 @@ For most suites upgrading is low risk. Run through this list, then read the deta
 
 If you use an AI coding agent that supports the [Agent Skills](https://agentskills.io/specification) spec (such as GitHub Copilot or Claude), two community **skills** in [github/awesome-copilot](https://github.com/github/awesome-copilot) teach the agent to do these migrations the way this guide describes. The agent loads a skill on demand when you ask it to upgrade a suite, so instead of guessing it follows the documented symptom → fix steps, runs your tests, and fixes them file by file.
 
-:::note Experimental / preview
-Both skills track Pester 6 while it is a release candidate, so their guidance may change alongside the release. Always review the diff and re-run your suite afterward — treat the agent as an assistant, not an unchecked bulk-editor.
+:::note Review the changes
+These skills teach the agent the documented migration steps, but they don't run or vet your suite for you. Always review the diff and re-run your suite afterward — treat the agent as an assistant, not an unchecked bulk-editor.
 :::
 
 | Skill | What it does |
@@ -320,7 +320,3 @@ If a value or type assertion fails because the pipeline unwrapped a collection t
 ```
 
 The hint is best-effort. PowerShell can't reliably tell a single-item collection from a scalar, and a collection's original type isn't visible on the right-hand side of the pipeline. Pester recovers the piped value through pipeline tricks that work for common cases but not every one, so the hint won't appear in every situation. When you need the exact value or the concrete collection type, pass it with `-Actual` rather than relying on the hint.
-
-:::warning Pester 6.0.0 is in preview
-Some details may still change before the final release. To keep up with the latest development, see the release notes for 6.0.0 pre-release builds at https://github.com/pester/Pester/releases
-:::

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -157,18 +157,17 @@ const config = {
           sidebarPath: './sidebars.js',
           editUrl: 'https://github.com/pester/docs/edit/main',
           // Define which version ("current" vs versioned docs like "v5") that will use unversioned URIs /docs/...
-          // Using v5 while it's latest stable.
+          // "current" (v6) is the latest stable version.
           // When updated, also update static/_redirects to always support versioned URIs
-          lastVersion: "v5",
+          lastVersion: "current",
           includeCurrentVersion: true,
           disableVersioning: false,
           versions: {
             // "current" is content in /docs folder
             current: {
-              label: "v6 (preview) 🚧",
-              // path is /docs/next by default unless lastVersion is set to "current"
-              // overriden to /docs/v6 during preview
-              path: "v6"
+              label: "v6",
+              // Empty path so the latest version (v6) uses unversioned URIs /docs/...
+              path: ""
             }
           },
         },

--- a/static/_redirects
+++ b/static/_redirects
@@ -3,5 +3,5 @@
 /issues/docs            https://github.com/pester/docs/issues/new/choose
 /releases/:v            https://github.com/pester/pester/releases/tag/:v
 
-# Redirect versioned URLs for latest (e.g. /docs/v5 -> /docs)
-/docs/v5/*              /docs/:splat    302
+# Redirect versioned URLs for latest (e.g. /docs/v6 -> /docs)
+/docs/v6/*              /docs/:splat    302


### PR DESCRIPTION
## What

Prepares the docs to make **v6 the current/latest version** and removes the work-in-progress markers now that v6 is being finalized.

## Changes

**`docusaurus.config.js`** — v6 is now latest
- `lastVersion: "v5"` → `"current"` (v6 content lives in `/docs`)
- Version label `"v6 (preview) 🚧"` → `"v6"`
- `path: "v6"` → `""` so v6 serves at unversioned `/docs/...`
- Updated the explanatory comments

**`static/_redirects`** — redirect the now-latest version's versioned URL
- `/docs/v5/*` → `/docs/v6/*` → `/docs/:splat`, so legacy `/docs/v6` preview links resolve to `/docs`. v5 now keeps its own `/docs/v5/...` URLs.

**`docs/migrations/v5-to-v6.mdx`** — remove work-in-progress notices
- Deleted the `:::warning Pester 6.0.0 is in preview` admonition
- Reworded the `:::note Experimental / preview` skills note to drop the release-candidate framing (kept the "review the diff / re-run your suite" advice)

## Banner

v5 now shows the **same "unmaintained" banner as v4** — _"This is documentation for Pester v5, which is no longer actively maintained. For up-to-date documentation, see the latest version (v6)."_ This comes automatically from the `lastVersion` change, the same default mechanism v4 already uses (no explicit per-version banner config).

## Verification

Ran a full `yarn build`:
- **v6** serves at `/docs`, labeled just "v6", no banner
- **v5** (`/docs/v5`) and **v4** (`/docs/v4`) show identical unmaintained banners pointing to v6 as latest
- Version dropdown lists v6, v5, v4; build succeeded with no errors

## Notes

- `versions.json` stays `["v5", "v4"]` — v6 is the "current" version, not a cut/versioned one.
- Left the feature-level `:::warning Experimental` notices (parallel execution, result object) untouched — those describe experimental features _within_ released v6, not preview status.