### PR TITLE
Add custom `:::experimental` admonition for experimental features

### DIFF
--- a/docs/usage/parallel.mdx
+++ b/docs/usage/parallel.mdx
@@ -3,7 +3,7 @@ title: Parallel execution
 description: Pester v6 can run test files in parallel, each file in its own runspace, to cut the wall-clock time of large suites. This experimental feature is enabled with a single configuration option.
 ---
 
-:::warning Experimental
+:::experimental
 Parallel execution is experimental in Pester v6. Treat `Run.Parallel` as opt-in. The directive name, configuration shape, and behavior may still change before it is declared stable.
 :::
 

--- a/docs/usage/result-object.mdx
+++ b/docs/usage/result-object.mdx
@@ -195,7 +195,7 @@ In a normal sequential run the `Run.Duration` equals the sum of its container du
 
 ## Parallel runner edge cases
 
-:::warning Experimental
+:::experimental
 The parallel runner is **experimental** in Pester 6 and its behaviour may still change. It requires **PowerShell 7.4+**.
 :::
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -160,6 +160,12 @@ const config = {
         docs: {
           sidebarPath: './sidebars.js',
           editUrl: 'https://github.com/pester/docs/edit/main',
+          // Register the custom ":::experimental" admonition (see
+          // src/theme/Admonition) alongside the built-in note/tip/info/warning/danger.
+          admonitions: {
+            keywords: ['experimental'],
+            extendDefaults: true,
+          },
           // Define which version ("current" vs versioned docs like "v5") that will use unversioned URIs /docs/...
           // "current" (v6) is the latest stable version.
           // When updated, also update static/_redirects to always support versioned URIs

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -217,3 +217,18 @@ table {
   padding: 10px;
   vertical-align: middle;
 }
+/* Custom ":::experimental" admonition palette (purple "danger zone" look).
+   Mirrors how Infima's built-in alert variants set the --ifm-alert-* vars. */
+.alert--experimental {
+  --ifm-alert-background-color: #f6f0ff;
+  --ifm-alert-background-color-highlight: rgba(146, 84, 222, 0.15);
+  --ifm-alert-foreground-color: #4b1f8f;
+  --ifm-alert-border-color: #9254de;
+}
+
+[data-theme='dark'] .alert--experimental {
+  --ifm-alert-background-color: #2a1d3d;
+  --ifm-alert-background-color-highlight: rgba(179, 136, 255, 0.15);
+  --ifm-alert-foreground-color: #e2d1ff;
+  --ifm-alert-border-color: #b388ff;
+}

--- a/src/theme/Admonition/Type/Experimental.js
+++ b/src/theme/Admonition/Type/Experimental.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import clsx from 'clsx';
+import AdmonitionLayout from '@theme/Admonition/Layout';
+
+// Custom "experimental" admonition used to flag features that are opt-in and
+// may still change (e.g. parallel execution, global mocks). Rendered with a
+// distinct purple palette defined in src/css/custom.css (.alert--experimental).
+const infimaClassName = 'alert alert--experimental';
+
+const defaultProps = {
+  icon: (
+    <span role="img" aria-label="Test tube">
+      🧪
+    </span>
+  ),
+  title: 'Experimental',
+};
+
+export default function AdmonitionTypeExperimental(props) {
+  return (
+    <AdmonitionLayout
+      {...defaultProps}
+      {...props}
+      className={clsx(infimaClassName, props.className)}>
+      {props.children}
+    </AdmonitionLayout>
+  );
+}

--- a/src/theme/Admonition/Types.js
+++ b/src/theme/Admonition/Types.js
@@ -1,0 +1,9 @@
+import DefaultAdmonitionTypes from '@theme-original/Admonition/Types';
+import AdmonitionTypeExperimental from '@site/src/theme/Admonition/Type/Experimental';
+
+const AdmonitionTypes = {
+  ...DefaultAdmonitionTypes,
+  experimental: AdmonitionTypeExperimental,
+};
+
+export default AdmonitionTypes;


### PR DESCRIPTION
## What

Adds a reusable `:::experimental` Docusaurus admonition so we can consistently flag opt-in, still-changing features (parallel execution, the new global mock, etc.) — a purpose-built "danger zone" header instead of hand-typed `:::warning Experimental` boxes.

It renders with a distinct **purple palette** and a 🧪 icon (light + dark mode), so it reads differently from a normal warning.

## How to use

```markdown
:::experimental
Parallel execution is experimental in Pester v6 and may still change.
:::
```

Custom title still works: `:::experimental Danger zone` — otherwise it defaults to **Experimental**.

## Changes

- **`docusaurus.config.js`** — register the `experimental` admonition keyword (`extendDefaults: true`, so the built-ins are untouched).
- **`src/theme/Admonition/Types.js`** — swizzle the admonition type map to add `experimental`.
- **`src/theme/Admonition/Type/Experimental.js`** — the component (icon + default title, mirrors the built-in Warning/Danger components).
- **`src/css/custom.css`** — `.alert--experimental` palette for light and dark themes.
- **`docs/usage/parallel.mdx`, `docs/usage/result-object.mdx`** — convert the two existing `:::warning Experimental` callouts to `:::experimental`.

## Notes

- `docs/usage/configuration.mdx` still uses inline `EXPERIMENTAL:` prefixes inside the generated config reference table — those are table cells, not standalone callouts, so they're intentionally left as-is.
- `yarn build` passes; verified the rendered markup includes `alert alert--experimental`, the 🧪 icon, and the **Experimental** title.

Opening as a draft so the deploy preview can be reviewed.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>