### PR TITLE
Use v6 Should-* syntax in docs examples

### DIFF
--- a/docs/migrations/breaking-changes-in-v5.mdx
+++ b/docs/migrations/breaking-changes-in-v5.mdx
@@ -14,7 +14,7 @@ description: Pester v5 included an all-new runtime which lead to some breaking c
 - PowerShell 2 is no longer supported
 - Legacy syntax `Should Be` (without `-`) is removed, see [Migrating from Pester v3 to v4](./v3-to-v4)
 - Mocks are scoped based on their placement, not in whole `Describe` / `Context`. The count also depends on their placement. See [mock scoping](../usage/mocking#mocks-are-scoped-based-on-their-placement)
-- `Assert-VerifiableMocks` was removed, see [Should -Invoke](../usage/mocking#should--invoke)
+- `Assert-VerifiableMocks` was removed, see [Should-Invoke](../usage/mocking#should-invoke)
 - All code placed in the body of `Describe` outside of `It`, `BeforeAll`, `BeforeEach`, `AfterAll`, `AfterEach` will run during discovery and it's state might or might not be available to the test code, see [Discovery and Run](../usage/discovery-and-run)
 - `-Output` parameter has reduced options to `None`, `Normal`, `Detailed` and `Diagnostic`. `-Show` alias is removed
 - `-PesterOption` switch is removed

--- a/docs/quick-start.mdx
+++ b/docs/quick-start.mdx
@@ -73,7 +73,7 @@ BeforeAll {
 Describe 'Get-Planet' {
     It 'Given no parameters, it lists all 8 planets' {
         $allPlanets = Get-Planet
-        $allPlanets.Count | Should -Be 8
+        $allPlanets.Count | Should-Be 8
     }
 }
 ```
@@ -114,7 +114,7 @@ Here are few examples:
 ```powershell
 It 'Earth is the third planet in our Solar System' {
     $allPlanets = Get-Planet
-    $allPlanets[2].Name | Should -Be 'Earth'
+    $allPlanets[2].Name | Should-Be 'Earth'
 }
 ```
 
@@ -122,7 +122,7 @@ It 'Earth is the third planet in our Solar System' {
 It 'Pluto is not part of our Solar System' {
     $allPlanets = Get-Planet
     $plutos = $allPlanets | Where-Object Name -EQ 'Pluto'
-    $plutos.Count | Should -Be 0
+    $plutos.Count | Should-Be 0
 }
 ```
 
@@ -130,7 +130,7 @@ It 'Pluto is not part of our Solar System' {
 It 'Planets have this order: Mercury, Venus, Earth, Mars, Jupiter, Saturn, Uranus, Neptune' {
     $allPlanets = Get-Planet
     $planetsInOrder = $allPlanets.Name -join ', '
-    $planetsInOrder | Should -Be 'Mercury, Venus, Earth, Mars, Jupiter, Saturn, Uranus, Neptune'
+    $planetsInOrder | Should-Be 'Mercury, Venus, Earth, Mars, Jupiter, Saturn, Uranus, Neptune'
 }
 ```
 
@@ -164,27 +164,27 @@ Running tests from 1 files.
 Running tests from 'C:\t\Planets\Get-Planet.Tests.ps1'
 Describing Get-Planet
   [-] Given no parameters, it lists all 8 planets 19ms
-   Expected 8, but got 9.
-   at $allPlanets.Count | Should -Be 8, C:\t\Planets\Get-Planet.Tests.ps1:22
+   Expected [int] 8, but got [int] 9.
+   at $allPlanets.Count | Should-Be 8, C:\t\Planets\Get-Planet.Tests.ps1:22
 Tests completed in 183ms
 Tests Passed: 0, Failed: 1, Skipped: 0, Inconclusive: 0, NotRun: 0
 ```
 
-The error is: `Expected 8, but got 9.`, this exactly reflects the change that we made to the tested function. We added one more item to the collection of planets, and the test confirms that the function is now broken.
+The error is: `Expected [int] 8, but got [int] 9.`, this exactly reflects the change that we made to the tested function. We added one more item to the collection of planets, and the test confirms that the function is now broken.
 
 ### Breaking our test, by breaking the test expectation
 
-The change that we just did is not the only change that we can make to break the test. There are other ways to do it. We can change the expected count to be 1, saying that there is just one planet orbiting the Sun, by changing the `Should` to `$allPlanets.Count | Should -Be 1`. This will also break the test:
+The change that we just did is not the only change that we can make to break the test. There are other ways to do it. We can change the expected count to be 1, saying that there is just one planet orbiting the Sun, by changing the `Should` to `$allPlanets.Count | Should-Be 1`. This will also break the test:
 
 ```
 Describing Get-Planet
   [-] Given no parameters, it lists all 8 planets 25ms
-   Expected 1, but got 8.
-   at $allPlanets.Count | Should -Be 1, C:\t\Planets\Get-Planet.Tests.ps1:21
+   Expected [int] 1, but got [int] 8.
+   at $allPlanets.Count | Should-Be 1, C:\t\Planets\Get-Planet.Tests.ps1:21
 Tests completed in 195ms
 ```
 
-The error is: `Expected 1, but got 8.`, this again reflects exactly what we did in the test, but it no longer reflects the real world.
+The error is: `Expected [int] 1, but got [int] 8.`, this again reflects exactly what we did in the test, but it no longer reflects the real world.
 
 ### How tests break
 
@@ -263,7 +263,7 @@ BeforeAll {
 Describe 'Get-Planet' {
     It 'Given no parameters, it lists all 8 planets' {
         $allPlanets = Get-Planet
-        $allPlanets.Count | Should -Be 8
+        $allPlanets.Count | Should-Be 8
     }
 }
 ```
@@ -297,7 +297,7 @@ BeforeAll {
 Describe 'Get-Planet' {
     It 'Given no parameters, it lists all 8 planets' {
         $allPlanets = Get-Planet
-        $allPlanets.Count | Should -Be 8
+        $allPlanets.Count | Should-Be 8
     }
 }
 ```

--- a/docs/usage/code-coverage.mdx
+++ b/docs/usage/code-coverage.mdx
@@ -73,11 +73,11 @@ BeforeAll {
 
 Describe 'Demonstrating Code Coverage' {
     It 'Calls FunctionOne with no switch parameter set' {
-        FunctionOne | Should -Be 'SwitchParam was not set'
+        FunctionOne | Should-Be 'SwitchParam was not set'
     }
 
     It 'Calls FunctionTwo' {
-        FunctionTwo | Should -Be 'I get executed'
+        FunctionTwo | Should-Be 'I get executed'
     }
 }
 ```

--- a/docs/usage/configuration.mdx
+++ b/docs/usage/configuration.mdx
@@ -85,7 +85,7 @@ BeforeAll {
 Describe "pester preference" {
     It "mocks" {
         Mock a { "mock" }
-        a | Should -Be "mock"
+        a | Should-Be "mock"
     }
 }
 ```

--- a/docs/usage/data-driven-tests.mdx
+++ b/docs/usage/data-driven-tests.mdx
@@ -25,7 +25,7 @@ Describe "Get-Emoji" {
         @{ Name = "cactus"; Expected = '🌵'}
         @{ Name = "giraffe"; Expected = '🦒'}
     ) {
-        Get-Emoji -Name $name | Should -Be $expected
+        Get-Emoji -Name $name | Should-Be $expected
     }
 }
 ```
@@ -39,11 +39,11 @@ The code above will generate tests that are equivalent to this:
 ```powershell
 Describe "Get-Emoji" {
     It "Returns 🌵 (cactus)" {
-        Get-Emoji -Name cactus | Should -Be '🌵'
+        Get-Emoji -Name cactus | Should-Be '🌵'
     }
 
     It "Returns 🦒 (giraffe)" {
-        Get-Emoji -Name giraffe | Should -Be '🦒'
+        Get-Emoji -Name giraffe | Should-Be '🦒'
     }
 }
 ```
@@ -60,7 +60,7 @@ Describe "Get-Emoji" {
         @{ Name = "penguin"; Expected = '🐧'}
         @{ Name = "smiling face with smiling eyes"; Expected = '😊'}
     ) {
-        Get-Emoji -Name $name | Should -Be $expected
+        Get-Emoji -Name $name | Should-Be $expected
     }
 }
 ```
@@ -75,11 +75,11 @@ Describe "Get-Emoji <name>" -ForEach @(
     @{ Name = "giraffe"; Symbol = '🦒'; Kind = 'Animal' }
 ) {
     It "Returns <symbol>"  {
-        Get-Emoji -Name $name | Should -Be $symbol
+        Get-Emoji -Name $name | Should-Be $symbol
     }
 
     It "Has kind <kind>" {
-        Get-Emoji -Name $name | Get-EmojiKind | Should -Be $kind
+        Get-Emoji -Name $name | Get-EmojiKind | Should-Be $kind
     }
 }
 ```
@@ -89,21 +89,21 @@ Which is equivalent to writing:
 ```powershell
 Describe "Get-Emoji cactus" {
     It "Returns 🌵" {
-        Get-Emoji -Name cactus | Should -Be '🌵'
+        Get-Emoji -Name cactus | Should-Be '🌵'
     }
 
     It "Has kind Plant" {
-        Get-Emoji -Name cactus | Get-EmojiKind | Should -Be 'Plant'
+        Get-Emoji -Name cactus | Get-EmojiKind | Should-Be 'Plant'
     }
 }
 
 Describe "Get-Emoji giraffe" {
     It "Returns 🦒" {
-        Get-Emoji -Name giraffe | Should -Be '🦒'
+        Get-Emoji -Name giraffe | Should-Be '🦒'
     }
 
     It "Has kind Animal" {
-        Get-Emoji -Name giraffe | Get-EmojiKind | Should -Be 'Animal'
+        Get-Emoji -Name giraffe | Get-EmojiKind | Should-Be 'Animal'
     }
 }
 ```
@@ -133,17 +133,17 @@ Describe "Get-Emoji <name>" -ForEach @(
     }
 ) {
     It "Returns <symbol>"  {
-        Get-Emoji -Name $name | Should -Be $symbol
+        Get-Emoji -Name $name | Should-Be $symbol
     }
 
     It "Has kind <kind>" {
-        Get-Emoji -Name $name | Get-EmojiKind | Should -Be $kind
+        Get-Emoji -Name $name | Get-EmojiKind | Should-Be $kind
     }
 
     Context "Runes (each character in multibyte emoji)" -ForEach $runes {
         It "Has rune <rune> on index <index>" {
             $actual = @((Get-Emoji -Name $name).EnumerateRunes())
-            $actual[$index].Value | Should -Be $rune
+            $actual[$index].Value | Should-Be $rune
         }
     }
 }
@@ -156,19 +156,19 @@ Describe "Get-Emoji <name>" -ForEach @(
 ```powershell
 Describe "Get-FruitBasket" {
     It "Contains <_>" -ForEach '🍎','🍌','🥝','🥑','🍇','🍐' {
-        Get-FruitBasket | Should -Contain $_
+        Get-FruitBasket | Should-ContainCollection $_
     }
 }
 
 Describe "Get-FruitBasket" {
     Context "Fruit <_>" -ForEach '🍎','🍌','🥝','🥑','🍇','🍐' {
         It "Contains <_> by default" {
-            Get-FruitBasket | Should -Contain $_
+            Get-FruitBasket | Should-ContainCollection $_
         }
 
         It "Can remove <_> from the basket" {
             Remove-FruitBasket -Item $_
-            Get-FruitBasket | Should -Not -Contain $_
+            Get-FruitBasket | Should-NotContainCollection $_
         }
     }
     AfterAll {
@@ -597,7 +597,7 @@ $name = "Jakub"
 
 Describe "d" {
     It "My name is: $name" {
-        $name | Should -be "Jakub"
+        $name | Should-Be "Jakub"
     }
 }
 ```
@@ -607,8 +607,8 @@ Running tests from 1 files.
 Running tests from 'C:\p\g.Tests.ps1'
 Describing d
   [-] My name is: Jakub 106ms
-   Expected 'Jakub', but got $null.
-   at $name | Should -be "Jakub", C:\p\g.Tests.ps1:5
+   Expected [string] 'Jakub', but got [null] $null.
+   at $name | Should-Be "Jakub", C:\p\g.Tests.ps1:5
 Tests completed in 436ms
 Tests Passed: 0, Failed: 1, Skipped: 0, Inconclusive: 0, NotRun: 0
 ```

--- a/docs/usage/discovery-and-run.mdx
+++ b/docs/usage/discovery-and-run.mdx
@@ -44,7 +44,7 @@ Describe "Get-Emoji" {
         @{ Name = "cactus"; Expected = '🌵'}
         @{ Name = "giraffe"; Expected = '🦒'}
     ) {
-        Get-Emoji -Name $name | Should -Be $expected
+        Get-Emoji -Name $name | Should-Be $expected
     }
 }
 
@@ -83,11 +83,11 @@ Container: Get-Emoji.Tests.ps1
         Tests:
             Test: Returns <expected> (<name>)
             Data: @{ Name = "cactus"; Expected = '🌵'}
-            ScriptBlock: { Get-Emoji -Name $name | Should -Be $expected }
+            ScriptBlock: { Get-Emoji -Name $name | Should-Be $expected }
 
             Test: Returns <expected> (<name>)
             Data: @{ Name = "giraffe"; Expected = '🦒'}
-            ScriptBlock: { Get-Emoji -Name $name | Should -Be $expected }
+            ScriptBlock: { Get-Emoji -Name $name | Should-Be $expected }
 ```
 
 Now we would go through all the objects, check filters and propagate them down and back up. This gives us the final overview of what needs to run. In this case there are no filters, so nothing changes and all tests will be invoked.

--- a/docs/usage/importing-tested-functions.mdx
+++ b/docs/usage/importing-tested-functions.mdx
@@ -55,7 +55,7 @@ $sut = (Split-Path -Leaf $MyInvocation.MyCommand.Path).Replace(".Tests.", ".")
 
 Describe "Get-Cactus" {
     It "Returns 🌵" {
-        Get-Cactus | Should -Be '🌵'
+        Get-Cactus | Should-Be '🌵'
     }
 }
 ```
@@ -70,7 +70,7 @@ BeforeAll {
 
 Describe "Get-Cactus" {
     It "Returns 🌵" {
-        Get-Cactus | Should -Be '🌵'
+        Get-Cactus | Should-Be '🌵'
     }
 }
 ```

--- a/docs/usage/mocking.mdx
+++ b/docs/usage/mocking.mdx
@@ -21,11 +21,11 @@ With the set of Mocking functions that Pester exposes, one can:
 
 Mocks the behavior of an existing command with an alternate implementation.
 
-### Should -Invoke
+### Should-Invoke
 
 Checks if a mocked command has been called a certain number of times and throws an exception if it has not.
 
-### Should -InvokeVerifiable
+### Should-Invoke -Verifiable
 
 Checks if any verifiable Mock has not been invoked. If so, this will throw an exception.
 
@@ -64,11 +64,11 @@ Describe "BuildIfChanged" {
         }
 
         It "Builds the next version" {
-            Should -InvokeVerifiable
+            Should-Invoke -Verifiable
         }
 
         It "returns the next version number" {
-            $result | Should -Be 1.2
+            $result | Should-Be 1.2
         }
     }
     Context "When there are no Changes" {
@@ -81,7 +81,7 @@ Describe "BuildIfChanged" {
         }
 
         It "Should not build the next version" {
-            Should -Invoke -CommandName Build -Times 0 -ParameterFilter {$version -eq 1.1}
+            Should-Invoke -CommandName Build -Times 0 -ParameterFilter {$version -eq 1.1}
         }
     }
 }
@@ -145,10 +145,10 @@ Describe 'Mocking native commands' {
 
         GetHTTPHeader -url 'https://google.com'
 
-        Should -Invoke -CommandName 'curl' -Exactly -Times 1 -ParameterFilter { $args[0] -eq '--url' -and $args[1] -eq 'https://google.com' }
+        Should-Invoke -CommandName 'curl' -Exactly -Times 1 -ParameterFilter { $args[0] -eq '--url' -and $args[1] -eq 'https://google.com' }
 
         # By converting args to string (will concat using space by default) you can match a pattern if order might change. remember linebreaks
-        Should -Invoke -CommandName 'curl' -Exactly -Times 1 -ParameterFilter { "$args" -match '--url https://google.com -I' }
+        Should-Invoke -CommandName 'curl' -Exactly -Times 1 -ParameterFilter { "$args" -match '--url https://google.com -I' }
     }
 }
 ```
@@ -189,11 +189,11 @@ Describe "d" {
 
     It "i" {
         Mock f { "mock" }
-        f | Should -Be "mock"
+        f | Should-Be "mock"
     }
 
     It "j" {
-        f | Should -Be "real"
+        f | Should-Be "real"
     }
 }
 
@@ -204,11 +204,11 @@ Describe "d" {
     }
 
     It "i" {
-        f | Should -Be "mock"
+        f | Should-Be "mock"
     }
 
     It "j" {
-        f | Should -Be "mock"
+        f | Should-Be "mock"
     }
 }
 ```
@@ -227,25 +227,25 @@ Describe "d" {
 
     It "i" {
         f
-        Should -Invoke f -Exactly 1
+        Should-Invoke f -Exactly 1
     }
 
     It "j" {
         f
-        Should -Invoke f -Exactly 1
+        Should-Invoke f -Exactly 1
     }
 
     It "k" {
         f
-        Should -Invoke f -Exactly 3 -Scope Describe
+        Should-Invoke f -Exactly 3 -Scope Describe
     }
 
     AfterEach {
-        Should -Invoke f -Exactly 1
+        Should-Invoke f -Exactly 1
     }
 
     AfterAll {
-        Should -Invoke f -Exactly 3
+        Should-Invoke f -Exactly 3
     }
 }
 ```
@@ -265,12 +265,12 @@ Describe "d" {
 
     It "i" {
         f 10
-        Should -Invoke f -Exactly 1 -ParameterFilter { $a -eq 10 }
+        Should-Invoke f -Exactly 1 -ParameterFilter { $a -eq 10 }
     }
 
     It "j" {
         f 20
-        Should -Invoke f -Exactly 0 -ParameterFilter { $a -eq 10 }
+        Should-Invoke f -Exactly 0 -ParameterFilter { $a -eq 10 }
     }
 }
 ```
@@ -290,7 +290,7 @@ Describe "d" {
 
     It "throws when nothing matches" {
         # In v5 this returned "real:2"; in v6 it throws:
-        { Get-Thing 2 } | Should -Throw "*no default mock to fall back to*"
+        { Get-Thing 2 } | Should-Throw -ExceptionMessage "*no default mock to fall back to*"
     }
 }
 ```
@@ -304,7 +304,7 @@ Mock Get-Thing { "one" } -ParameterFilter { $Id -eq 1 }  # specific case
 
 ### Mock history
 
-When a `Should -Invoke` assertion fails, Pester v6 prints the recorded mock history for the command. It lists every recorded call and marks whether each one matched your parameter filter, so you can see why a filter did or didn't match without adding your own `Write-Host` debugging.
+When a `Should-Invoke` assertion fails, Pester v6 prints the recorded mock history for the command. It lists every recorded call and marks whether each one matched your parameter filter, so you can see why a filter did or didn't match without adding your own `Write-Host` debugging.
 
 ```powershell title="Order.Tests.ps1"
 BeforeAll {
@@ -318,7 +318,7 @@ Describe 'Order processing' {
         Send-Email -To 'alice@example.com' -Subject 'Welcome'
         Send-Email -To 'bob@example.com'   -Subject 'Receipt'
 
-        Should -Invoke Send-Email -Times 2 -Exactly -ParameterFilter { $To -eq 'alice@example.com' }
+        Should-Invoke Send-Email -Times 2 -Exactly -ParameterFilter { $To -eq 'alice@example.com' }
     }
 }
 ```
@@ -331,7 +331,7 @@ The assertion fails because only one of the two calls matched the filter, and th
  Performed invocations:
    [*] Send-Email -To 'alice@example.com' -Subject 'Welcome' from Order.Tests.ps1:7
    [ ] Send-Email -To 'bob@example.com' -Subject 'Receipt' from Order.Tests.ps1:7
- at Should -Invoke Send-Email -Times 2 -Exactly -ParameterFilter { $To -eq 'alice@example.com' }, Order.Tests.ps1:12
+ at Should-Invoke Send-Email -Times 2 -Exactly -ParameterFilter { $To -eq 'alice@example.com' }, Order.Tests.ps1:12
 ```
 
 `[*]` marks a call that matched the parameter filter and `[ ]` marks one that didn't. Here `alice` matched and `bob` didn't, so the matched count is 1 instead of the expected 2.

--- a/docs/usage/modules.mdx
+++ b/docs/usage/modules.mdx
@@ -57,11 +57,11 @@ Describe "BuildIfChanged" {
         }
 
         It "Builds the next version and calls Write-Host" {
-            Should -InvokeVerifiable
+            Should-Invoke -Verifiable
         }
 
         It "returns the next version number" {
-            $result | Should -Be 1.2
+            $result | Should-Be 1.2
         }
     }
 
@@ -77,7 +77,7 @@ Describe "BuildIfChanged" {
         It "Should not build the next version" {
             # -Scope Context is used below since BuildIfChanged is called in BeforeAll
             # It's not required when the mock is called inside It
-            Should -Invoke Build -ModuleName MyModule -Times 0 -Scope Context -ParameterFilter {
+            Should-Invoke Build -ModuleName MyModule -Times 0 -Scope Context -ParameterFilter {
                 $version -eq 1.1
             }
         }
@@ -87,7 +87,7 @@ Describe "BuildIfChanged" {
 
 ### -ModuleName
 
-Notice that in this example test script, all calls to [Mock](../commands/Mock) and [Should -Invoke](../commands/Should) have had the `-ModuleName MyModule` parameter added. This tells Pester to inject the mock into the module's scope, which causes any calls to those commands from inside the module to execute the mock instead.
+Notice that in this example test script, all calls to [Mock](../commands/Mock) and [Should-Invoke](../commands/Should-Invoke) have had the `-ModuleName MyModule` parameter added. This tells Pester to inject the mock into the module's scope, which causes any calls to those commands from inside the module to execute the mock instead.
 
 When you write your test script this way, you can mock commands that are called by the module's internal functions. However, your test script is still limited to accessing the public, exported members of the module. If you wanted to write a unit test that calls `Build` directly, for example, it wouldn't work using the above technique. That's where the second approach to script module testing comes into play.
 
@@ -108,7 +108,7 @@ Describe "Unit testing the module's internal Build function:" {
 
             Build $testVersion
 
-            Should -Invoke Write-Host -ParameterFilter {
+            Should-Invoke Write-Host -ParameterFilter {
                 $Object -eq "a build was run for version: $testVersion"
             }
         }
@@ -116,7 +116,7 @@ Describe "Unit testing the module's internal Build function:" {
 }
 ```
 
-Notice that when using `InModuleScope`, you no longer need to specify a `-ModuleName` parameter when calling `Mock` or `Should -Invoke` for commands within that module. You are also able to directly call the `Build` function, which the module does not export.
+Notice that when using `InModuleScope`, you no longer need to specify a `-ModuleName` parameter when calling `Mock` or `Should-Invoke` for commands within that module. You are also able to directly call the `Build` function, which the module does not export.
 
 :::warning Avoid putting in InModuleScope around your Describe and It blocks.
 
@@ -167,13 +167,13 @@ Pester can be used to both test and mock the behavior commands that are exported
 Describe "Invoke-PublicMethod" {
     It "returns a value" {
         $result = Invoke-PublicMethod
-        $result | Should -Be 'Invoke-PublicMethod called!'
+        $result | Should-Be 'Invoke-PublicMethod called!'
     }
 
     It "mocking exported command" {
         Mock Invoke-PublicMethod { 'mocked' }
         $result = Invoke-PublicMethod
-        $result | Should -Be 'mocked'
+        $result | Should-Be 'mocked'
     }
 }
 ```
@@ -215,21 +215,21 @@ Describe 'Executing test code inside a dynamic module' {
     Context 'Using the Mock command' {
         It 'Can mock functions inside the module when using Mock -ModuleName' {
             Mock Invoke-PrivateFunction -ModuleName MyDynamicModule -MockWith { 'I am the mock function.' }
-            Invoke-PublicFunction | Should -Be 'I am the mock function.'
-            Should -Invoke Invoke-PrivateFunction -ModuleName MyDynamicModule
+            Invoke-PublicFunction | Should-Be 'I am the mock function.'
+            Should-Invoke Invoke-PrivateFunction -ModuleName MyDynamicModule
         }
     }
 
     It 'Can call module internal functions using InModuleScope' {
         InModuleScope MyDynamicModule {
-            Invoke-PrivateFunction | Should -Be 'I am the internal function'
+            Invoke-PrivateFunction | Should-Be 'I am the internal function'
         }
     }
     It 'Can mock functions inside the module without using Mock -ModuleName when inside InModuleScope' {
         InModuleScope MyDynamicModule {
             Mock Invoke-PrivateFunction -MockWith { 'I am the mock function.' }
-            Invoke-PrivateFunction | Should -Be 'I am the mock function.'
-            Should -Invoke Invoke-PrivateFunction
+            Invoke-PrivateFunction | Should-Be 'I am the mock function.'
+            Should-Invoke Invoke-PrivateFunction
         }
     }
 }

--- a/docs/usage/setup-and-teardown.mdx
+++ b/docs/usage/setup-and-teardown.mdx
@@ -36,11 +36,11 @@ Describe "API validation" {
     }
 
     It "response has Name = 'Pikachu'" {
-        $response.Name | Should -Be 'Pikachu'
+        $response.Name | Should-Be 'Pikachu'
     }
 
     It "response has Type = 'electric'" {
-        $response.Type | Should -Be 'electric'
+        $response.Type | Should-Be 'electric'
     }
 }
 ```
@@ -210,7 +210,7 @@ Describe "describe 1" {
     }
 
     It "acceptance test 1" -Tag "Acceptance" {
-        1 | Should -Be 1
+        1 | Should-Be 1
     }
 
     AfterAll {
@@ -242,7 +242,7 @@ Describe "d" {
     }
 
     It "Check a" {
-        $a | Should -Be "BeforeAll"
+        $a | Should-Be "BeforeAll"
     }
 
     AfterAll {

--- a/docs/usage/skip.mdx
+++ b/docs/usage/skip.mdx
@@ -11,27 +11,27 @@ description: Skipping tests can be useful in many scenarios or when certain cond
 Describe "describe1" {
     Context "with one skipped test" {
         It "test 1" -Skip {
-            1 | Should -Be 2
+            1 | Should-Be 2
         }
 
         It "test 2" {
-            1 | Should -Be 1
+            1 | Should-Be 1
         }
     }
 
     Describe "that is skipped" -Skip {
         It "test 3" {
-            1 | Should -Be 2
+            1 | Should-Be 2
         }
     }
 
     Context "that is skipped and has skipped test" -Skip {
         It "test 3" -Skip {
-            1 | Should -Be 2
+            1 | Should-Be 2
         }
 
         It "test 3" {
-            1 | Should -Be 2
+            1 | Should-Be 2
         }
     }
 }
@@ -69,15 +69,15 @@ $sb = {
         }
 
         It 'First Test' -Skip:$SkipFirst {
-            1 | Should -Be 1
+            1 | Should-Be 1
         }
 
         It 'Second Test' -Skip:($skipSecond -eq 1) {
-            1 | Should -Be 1
+            1 | Should-Be 1
         }
 
         It 'Third Test' {
-            1 | Should -Be 1
+            1 | Should-Be 1
         }
     }
 }

--- a/docs/usage/tags.mdx
+++ b/docs/usage/tags.mdx
@@ -18,34 +18,34 @@ Describe "Get-Beer" {
     Context "acceptance tests" -Tag "Acceptance" {
 
         It "acceptance test 1" -Tag "Slow", "Flaky" {
-            1 | Should -Be 1
+            1 | Should-Be 1
         }
 
         It "acceptance test 2" {
-            1 | Should -Be 1
+            1 | Should-Be 1
         }
 
         It "acceptance test 3" -Tag "WindowsOnly" {
-            1 | Should -Be 1
+            1 | Should-Be 1
         }
 
         It "acceptance test 4" -Tag "Slow" {
-            1 | Should -Be 1
+            1 | Should-Be 1
         }
 
         It "acceptance test 5" -Tag "LinuxOnly" {
-            1 | Should -Be 1
+            1 | Should-Be 1
         }
     }
 
     Context "unit tests" {
 
         It "unit test 1" {
-            1 | Should -Be 1
+            1 | Should-Be 1
         }
 
         It "unit test 2" -Tag "LinuxOnly" {
-            1 | Should -Be 1
+            1 | Should-Be 1
         }
 
     }

--- a/docs/usage/test-file-structure.mdx
+++ b/docs/usage/test-file-structure.mdx
@@ -20,7 +20,7 @@ BeforeAll {
 
 Describe "Get-Emoji" {
     It "Returns 🌵 (cactus)" {
-        Get-Emoji -Name cactus | Should -Be '🌵'
+        Get-Emoji -Name cactus | Should-Be '🌵'
     }
 }
 ```
@@ -45,11 +45,11 @@ BeforeAll {
 Describe "Get-Emoji" {
     Context "Lookup by whole name" {
         It "Returns 🌵 (cactus)" {
-            Get-Emoji -Name cactus | Should -Be '🌵'
+            Get-Emoji -Name cactus | Should-Be '🌵'
         }
 
         It "Returns 🦒 (giraffe)" {
-            Get-Emoji -Name giraffe | Should -Be '🦒'
+            Get-Emoji -Name giraffe | Should-Be '🦒'
         }
     }
 
@@ -60,15 +60,15 @@ Describe "Get-Emoji" {
             }
 
             It "Returns ✏️ (pencil)" {
-                $emojis | Should -Contain "✏️"
+                $emojis | Should-ContainCollection "✏️"
             }
 
             It "Returns 🐧 (penguin)" {
-                $emojis | Should -Contain "🐧"
+                $emojis | Should-ContainCollection "🐧"
             }
 
             It "Returns 😔 (pensive)" {
-                $emojis | Should -Contain "😔"
+                $emojis | Should-ContainCollection "😔"
             }
         }
 
@@ -78,15 +78,15 @@ Describe "Get-Emoji" {
             }
 
             It "Returns 🙂 (slightly smiling face)" {
-                $emojis | Should -Contain "🙂"
+                $emojis | Should-ContainCollection "🙂"
             }
 
             It "Returns 😁 (beaming face with smiling eyes)" {
-                $emojis | Should -Contain "😁"
+                $emojis | Should-ContainCollection "😁"
             }
 
             It "Returns 😊 (smiling face with smiling eyes)" {
-                $emojis | Should -Contain "😊"
+                $emojis | Should-ContainCollection "😊"
             }
         }
     }
@@ -120,7 +120,7 @@ Describe "Get-Emoji" {
             @{ Name = "cactus"; Expected = '🌵'}
             @{ Name = "giraffe"; Expected = '🦒'}
         ) {
-            Get-Emoji -Name $name | Should -Be $expected
+            Get-Emoji -Name $name | Should-Be $expected
         }
     }
 
@@ -135,7 +135,7 @@ Describe "Get-Emoji" {
                 @{ Name = "penguin"; Expected = '🐧'}
                 @{ Name = "pensive"; Expected = '😔'}
             ) {
-                $emojis | Should -Contain $expected
+                $emojis | Should-ContainCollection $expected
             }
         }
 
@@ -149,7 +149,7 @@ Describe "Get-Emoji" {
                 @{ Name = "beaming face with smiling eyes"; Expected = '😁'}
                 @{ Name = "smiling face with smiling eyes"; Expected = '😊'}
             ) {
-                $emojis | Should -Contain $expected
+                $emojis | Should-ContainCollection $expected
             }
         }
     }

--- a/docs/usage/testdrive.mdx
+++ b/docs/usage/testdrive.mdx
@@ -46,7 +46,7 @@ Describe "Add-Footer" {
     }
 
     It "adds a footer" {
-        (-join $result) | Should -Be "my test text.-Footer"
+        (-join $result) | Should-Be "my test text.-Footer"
     }
 }
 ```

--- a/docs/usage/testregistry.mdx
+++ b/docs/usage/testregistry.mdx
@@ -37,7 +37,7 @@ Describe "Get-InstallPath" {
     }
 
     It 'reads the install path from the registry' {
-        Get-InstallPath -Path "TestRegistry:\TestLocation" -Key "InstallPath" | Should -Be "C:\Program Files\MyApplication"
+        Get-InstallPath -Path "TestRegistry:\TestLocation" -Key "InstallPath" | Should-Be "C:\Program Files\MyApplication"
     }
 }
 ```


### PR DESCRIPTION
The getting started page and the usage docs still teach the classic `Should -Be` syntax. v6 recommends the new `Should-*` assertions, so the canonical examples should use them.

This converts the examples in `quick-start` and `docs/usage/*`. Pages that document the old syntax on purpose are left as they are: the classic, soft and custom assertion references, the migration guides, and the generated command reference under `docs/commands`.

A few conversions are not a plain rename:
- `Should -Contain` becomes `Should-ContainCollection` (membership in a collection).
- `Should -InvokeVerifiable` becomes `Should-Invoke -Verifiable`, and the `Should -Invoke` headings in `mocking.mdx` lose the space. The inbound anchor in `breaking-changes-in-v5` is updated to match.
- The failure output in `quick-start` now prints types, so `Expected 8, but got 9.` becomes `Expected [int] 8, but got [int] 9.`, matching what v6 actually prints.

Verified the converted examples and the mappings against Pester 6.0.0.