### PR TITLE
Add tip about Should -Not Throw replacement for v6 assertions

### DIFF
--- a/docs/assertions/should-command.mdx
+++ b/docs/assertions/should-command.mdx
@@ -480,6 +480,9 @@ All `Should-*` assertions are listed below, grouped by the kind of check they pe
 #### Exception
 
 - [`Should-Throw`](../commands/Should-Throw.mdx) — Asserts that a script block throws an exception.
+:::tip Missing Should-NotThrow?
+Use `& { ... }` to invoke the scriptblock, call the function or assert on the result. Any unexpected errors will fail the test.
+:::
 
 #### Mock
 


### PR DESCRIPTION
Include hint for `Should -Not -Throw` alternatives in v6 assertions docs. Originally planned for v5-to-v6 migration docs, but felt out of place without the rest.

Fix #411 