### PR TITLE
Declare @docusaurus/plugin-content-docs and @docusaurus/theme-common

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
   "dependencies": {
     "@docusaurus/core": "^3.10.2",
     "@docusaurus/faster": "^3.10.2",
+    "@docusaurus/plugin-content-docs": "^3.10.2",
     "@docusaurus/preset-classic": "^3.10.2",
+    "@docusaurus/theme-common": "^3.10.2",
     "@mdx-js/react": "^3.1.1",
     "@tanstack/react-table": "^8.21.3",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,9 +18,15 @@ importers:
       '@docusaurus/faster':
         specifier: ^3.10.2
         version: 3.10.2(@docusaurus/types@3.10.2(@swc/core@1.15.47)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(postcss@8.5.26)
+      '@docusaurus/plugin-content-docs':
+        specifier: ^3.10.2
+        version: 3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(@swc/core@1.15.47)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(postcss@8.5.26))(@mdx-js/react@3.1.1(@types/react@19.2.18)(react@19.2.8))(@rspack/core@1.7.12)(@swc/core@1.15.47)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@docusaurus/preset-classic':
         specifier: ^3.10.2
         version: 3.10.2(@algolia/client-search@5.56.0)(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(@swc/core@1.15.47)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(postcss@8.5.26))(@mdx-js/react@3.1.1(@types/react@19.2.18)(react@19.2.8))(@rspack/core@1.7.12)(@swc/core@1.15.47)(@types/react@19.2.18)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(search-insights@2.17.3)
+      '@docusaurus/theme-common':
+        specifier: ^3.10.2
+        version: 3.10.2(@docusaurus/plugin-content-docs@3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(@swc/core@1.15.47)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(postcss@8.5.26))(@mdx-js/react@3.1.1(@types/react@19.2.18)(react@19.2.8))(@rspack/core@1.7.12)(@swc/core@1.15.47)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@swc/core@1.15.47)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@mdx-js/react':
         specifier: ^3.1.1
         version: 3.1.1(@types/react@19.2.18)(react@19.2.8)


### PR DESCRIPTION
Main does not build since #435.

The tutorial components and the swizzled theme files from #421 import `@docusaurus/plugin-content-docs/client` and `@docusaurus/theme-common`, but neither package is in `package.json`. They only ever came in transitively through `@docusaurus/preset-classic`, and yarn hoisted them into a flat `node_modules` so the imports resolved anyway. pnpm uses a strict layout where a package that is not declared is not resolvable, so the client bundle now fails.

Both PRs are green on their own, it is the combination that breaks, so neither deploy preview caught it.

`pnpm build` on 1c880e9:

```
[ERROR] Client bundle compiled with errors therefore further build is impossible.
× Module not found: Can't resolve '@docusaurus/plugin-content-docs/client' in 'src/components/TutorialChecklist'
× Module not found: Can't resolve '@docusaurus/theme-common' in 'src/components/TutorialTracker'
× Module not found: Can't resolve '@docusaurus/plugin-content-docs/client' in 'src/pages'
× Module not found: Can't resolve '@docusaurus/plugin-content-docs/client' in 'src/theme/DocItem/Layout'
... 4 more
```

With this change `pnpm build` passes. The other `@docusaurus/*` imports in `src` are core aliases, not packages, so they need no entry.

🤖
