### PR TITLE
Clarify when BeforeDiscovery runs

### DIFF
--- a/docs/usage/discovery-and-run.mdx
+++ b/docs/usage/discovery-and-run.mdx
@@ -186,7 +186,7 @@ In this case the `foreach` is evaluated during `Discovery` because we simply run
 The example above has one more problem, if we move the setup to `BeforeDiscovery`, we will generate the tests correctly, and the `foreach` will define `$file` variable. But we won't be able to use the `$file` variable in the `It`. We need to attach it to the `It` using `-TestCases` with a single test case:
 
 ```powershell
-BeforeDiscovery { # <- this will run during Discovery
+BeforeDiscovery { # <- this runs in the Discovery phase, before the tests below are generated
     # check all script files
     $files = Get-ChildItem *.ps1
 }

--- a/versioned_docs/version-v5/usage/discovery-and-run.mdx
+++ b/versioned_docs/version-v5/usage/discovery-and-run.mdx
@@ -147,7 +147,7 @@ In this case the `foreach` is evaluated during `Discovery` because we simply run
 The example above has one more problem, if we move the setup to `BeforeDiscovery`, we will generate the tests correctly, and the `foreach` will define `$file` variable. But we won't be able to use the `$file` variable in the `It`. We need to attach it to the `It` using `-TestCases` with a single test case:
 
 ```powershell
-BeforeDiscovery { # <- this will run during Discovery
+BeforeDiscovery { # <- this runs in the Discovery phase, before the tests below are generated
     # check all script files
     $files = Get-ChildItem *.ps1
 }


### PR DESCRIPTION
The comment in the `BeforeDiscovery` example said "this will run during Discovery", and the name says before, so it reads as a contradiction. Someone got stuck on exactly that in https://github.com/pester/Pester/discussions/2827.

Same line fixed in the v5 versioned copy.
