### PR TITLE
Use the term "soft assertions" on the v5 Should page

### DIFF
--- a/versioned_docs/version-v5/assertions/should-command.mdx
+++ b/versioned_docs/version-v5/assertions/should-command.mdx
@@ -26,11 +26,11 @@ But was:  'Pester is bad.'
 Other assertion types can be found in [Assertion Reference](.).
 
 
-### Collect all Should failures
+### Collect all Should failures (soft assertions)
 
-`Should` can now be configured to continue on failure. This will report the error to Pester, but won't fail the test immediately. Instead, all the Should failures are collected and reported at the end of the test. This allows you to put multiple assertions into one It and still get complete information on failure.
+`Should` can now be configured to continue on failure. This will report the error to Pester, but won't fail the test immediately. Instead, all the Should failures are collected and reported at the end of the test. This allows you to put multiple assertions into one It and still get complete information on failure. This is known as a **soft assertion**.
 
-This new Should behavior is opt-in and can be enabled via `Should.ErrorAction = 'Continue'` on the configuration object or via `$PesterPreference`.
+This new Should behavior is opt-in and can be enabled via `Should.ErrorAction = 'Continue'` on the configuration object or via `$PesterPreference`. Setting `-ErrorAction Stop` on a single assertion makes that one fail the test immediately even when soft assertions are enabled, which is useful to guard a precondition.
 
 ```powershell
  BeforeAll {


### PR DESCRIPTION
The word "soft assertion" did not appear anywhere in the v5 docs, so searching pester.dev for it missed the page that actually describes the behavior. Renames the heading to "Collect all Should failures (soft assertions)", uses the term in the text, and mentions `-ErrorAction Stop` for guarding a precondition.

The v6 side of #385 is already done: [`assertions/soft-assertions`](https://pester.dev/docs/assertions/soft-assertions) landed in #397, it is in the sidebar, and all 41 generated `Should-*` pages carry the `-ErrorAction` explanation. So this is the last piece and #385 can close once it merges.

🤖
