### PR TITLE
Make the navbar and hero react to the theme

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -91,6 +91,8 @@
 }
 
 [data-theme='dark'] {
+  /* Same relationship as light mode: the navbar matches the middle of the hero gradient. */
+  --ifm-navbar-background-color: #00477a;
   --ifm-color-primary-light: #0089ee;
   --ifm-color-primary-lighter: #0294ff;
   --ifm-color-primary-lightest: #3eadff;

--- a/src/pages/styles.module.css
+++ b/src/pages/styles.module.css
@@ -37,8 +37,8 @@
   padding: 5rem 0 7rem;
   text-align: center;
   color: #fff;
-  background: radial-gradient(1200px 600px at 50% -10%, #2a93e6 0%, rgba(42, 147, 230, 0) 60%),
-    linear-gradient(160deg, #004a92 0%, #0072c6 55%, #0086dd 100%);
+  background: radial-gradient(1200px 600px at 50% -10%, var(--home-hero-glow) 0%, var(--home-hero-glow-fade) 60%),
+    linear-gradient(160deg, var(--home-hero-from) 0%, var(--home-hero-mid) 55%, var(--home-hero-to) 100%);
   clip-path: polygon(0 0, 100% 0, 100% calc(100% - 4vw), 0 100%);
 }
 .hero::before {
@@ -461,7 +461,7 @@
   text-align: center;
   padding: 5rem 0;
   color: #fff;
-  background: linear-gradient(120deg, #00508b 0%, #0072c6 100%);
+  background: linear-gradient(120deg, var(--home-cta-from) 0%, var(--home-cta-to) 100%);
 }
 .ctaTitle {
   font-size: clamp(1.8rem, 4vw, 2.6rem);
@@ -476,6 +476,13 @@
 
 /* --------------------------------------------------------------- theme vars */
 :global(:root) {
+  --home-hero-glow: rgb(42, 147, 230);
+  --home-hero-glow-fade: rgba(42, 147, 230, 0);
+  --home-hero-from: #004a92;
+  --home-hero-mid: #0072c6;
+  --home-hero-to: #0086dd;
+  --home-cta-from: #00508b;
+  --home-cta-to: #0072c6;
   --home-alt-bg: #f6f8fb;
   --home-card-bg: #ffffff;
   --home-border: #e2e8f0;
@@ -483,6 +490,13 @@
   --home-muted: #5b6b7f;
 }
 :global([data-theme='dark']) {
+  --home-hero-glow: rgb(14, 92, 156);
+  --home-hero-glow-fade: rgba(14, 92, 156, 0);
+  --home-hero-from: #002d58;
+  --home-hero-mid: #00477a;
+  --home-hero-to: #005285;
+  --home-cta-from: #00304f;
+  --home-cta-to: #00477a;
   --home-alt-bg: #12181f;
   --home-card-bg: #1a222c;
   --home-border: #2a3542;


### PR DESCRIPTION
The navbar background and the home page hero and CTA gradients follow the color theme.

`src/pages/styles.module.css` has a theme vars block with `--home-alt-bg`, `--home-card-bg` and friends, and a `[data-theme='dark']` override for them. The hero glow, the hero gradient and the CTA gradient move into that block. `custom.css` sets `--ifm-navbar-background-color` in its dark block.

## Colors

| | light | dark |
|---|---|---|
| navbar | `#0072c6` | `#00477a` |
| hero gradient | `#004a92`, `#0072c6`, `#0086dd` | `#002d58`, `#00477a`, `#005285` |
| hero glow | `#2a93e6` | `#0e5c9c` |
| CTA band | `#00508b`, `#0072c6` | `#00304f`, `#00477a` |

The light values are the ones already in the file, so light mode renders the same. In dark mode the navbar matches the middle of the hero gradient, which is what light mode already does. White text on the dark hero is between 8.3:1 and 13.9:1.

## Picking the dark shades

I checked a few other Docusaurus sites first. The ones that keep the chrome fixed keep it dark, so it still reads right in dark mode: prettier.io `#1a2b34`, electronjs.org `#1b1c26`, babeljs.io `#323330`. The ones with a bright brand color either theme it or leave the navbar neutral. redux.js.org is the closest case, it uses `hero--primary` and darkens the primary purple in the dark theme, `#764abc` becomes `#593d88`. Same idea here, keep the hue and drop the lightness.

All the numbers sit in one block at the bottom of `styles.module.css`, easy to nudge if the blue is too dark or too close to the page background.

🤖
