### PR TITLE
Refresh the tutorial output blocks against 6.1.0

### DIFF
--- a/tutorial/1-introduction/2-prerequisites.mdx
+++ b/tutorial/1-introduction/2-prerequisites.mdx
@@ -47,12 +47,12 @@ Import-Module Pester -PassThru
 ```
 
 ```
-ModuleType Version    PreRelease Name
----------- -------    ---------- ----
-Script     6.0.0                 Pester
+ModuleType Version    PreRelease Name                                ExportedCommands
+---------- -------    ---------- ----                                ----------------
+Script     6.1.0                 Pester                              {Add-ShouldOperator, …}
 ```
 
-If the version shown starts with a `6`, you are ready.
+If the version shown starts with a `6`, you are ready. A narrow terminal prints the same information as a list instead of a table, that is PowerShell formatting rather than anything being wrong.
 
 :::warning An old Pester can be loaded without you asking
 PowerShell loads a module automatically the first time you call one of its commands, and it picks the highest version it can find — but if an older Pester is *already* loaded in your session, it stays loaded. If the version above is not what you expect, open a fresh PowerShell session and check again before doing anything else.

--- a/tutorial/2-testing-a-module/1-setup.mdx
+++ b/tutorial/2-testing-a-module/1-setup.mdx
@@ -86,8 +86,8 @@ Import-Module ./Planetarium/Planetarium.psd1 -Force -PassThru
 ```
 Export-ModuleMember: Cannot bind parameter 'Function' to the target. Exception setting "Function": "Cannot process argument because the value of argument "pattern" is null. Change the value of argument "pattern" to a non-null value."
 
-ModuleType Version    PreRelease Name
----------- -------    ---------- ----
+ModuleType Version    PreRelease Name                                ExportedCommands
+---------- -------    ---------- ----                                ----------------
 Script     0.1.0                 Planetarium
 ```
 

--- a/tutorial/2-testing-a-module/2-first-test.mdx
+++ b/tutorial/2-testing-a-module/2-first-test.mdx
@@ -122,7 +122,7 @@ Invoke-Pester -Path ./Planetarium/Public
 
 ```
 Running tests from 1 files.
-[+] /home/you/pester-tutorial/Planetarium/Public/Get-Planet.Tests.ps1 305ms
+[+] /home/you/pester-tutorial/Planetarium/Public/Get-Planet.Tests.ps1 305ms (1 test)
 Tests completed in 313ms
 Tests Passed: 1, Failed: 0, Skipped: 0, Inconclusive: 0, NotRun: 0
 ```

--- a/tutorial/2-testing-a-module/5-output.mdx
+++ b/tutorial/2-testing-a-module/5-output.mdx
@@ -30,7 +30,7 @@ The full list is in [Configuration](../../docs/usage/configuration).
 
 ## Verbosity
 
-`Output.Verbosity` decides how much you see. The useful values are `None`, `Normal`, `Detailed` and `Diagnostic`.
+`Output.Verbosity` decides how much you see. The values are `None`, `Minimal`, `Normal`, `Detailed` and `Diagnostic`. `Minimal` is accepted but currently behaves as `Normal`, so the four worth knowing are the other ones.
 
 `Normal` is the default and reports per file — right for a suite you expect to pass:
 
@@ -41,10 +41,10 @@ Invoke-Pester -Configuration $config
 
 ```
 Running tests from 4 files.
-[+] /home/you/pester-tutorial/Planetarium/Private/ConvertTo-AstronomicalUnit.Tests.ps1 311ms
-[+] /home/you/pester-tutorial/Planetarium/Private/Test-PlanetName.Tests.ps1 45ms
-[+] /home/you/pester-tutorial/Planetarium/Public/Get-Planet.Tests.ps1 87ms
-[+] /home/you/pester-tutorial/Planetarium/Public/Get-PlanetDistance.Tests.ps1 48ms
+[+] /home/you/pester-tutorial/Planetarium/Private/ConvertTo-AstronomicalUnit.Tests.ps1 311ms (3 tests)
+[+] /home/you/pester-tutorial/Planetarium/Private/Test-PlanetName.Tests.ps1 45ms (4 tests)
+[+] /home/you/pester-tutorial/Planetarium/Public/Get-Planet.Tests.ps1 87ms (5 tests)
+[+] /home/you/pester-tutorial/Planetarium/Public/Get-PlanetDistance.Tests.ps1 48ms (3 tests)
 Tests completed in 502ms
 Tests Passed: 15, Failed: 0, Skipped: 0, Inconclusive: 0, NotRun: 0
 ```
@@ -57,7 +57,7 @@ Invoke-Pester -Configuration $config
 ```
 
 ```
-Pester v6.0.0
+Pester v6.1.0
 
 Running tests from 4 files.
 
@@ -134,7 +134,7 @@ Invoke-Pester -Configuration $config
   <environment machine-name="a6967ea17ed8" platform="Linux" ... />
 ```
 
-The default format is `NUnitXml`, which nearly every CI system understands. `JUnitXml` and `NUnit3` are also available via `TestResult.OutputFormat`. See [Test results](../../docs/usage/test-results) for which to pick.
+The default format is `NUnitXml`, which nearly every CI system understands. `NUnit2.5`, `NUnit3` and `JUnitXml` are the other values for `TestResult.OutputFormat`. See [Test results](../../docs/usage/test-results) for which to pick.
 
 The file is a build artifact — something a run produces, not source. If you keep your projects under version control, add it to your `.gitignore`:
 

--- a/tutorial/6-code-coverage/1-measuring.mdx
+++ b/tutorial/6-code-coverage/1-measuring.mdx
@@ -34,6 +34,7 @@ Invoke-Pester -Configuration $config
 Tests completed in 870ms
 Tests Passed: 24, Failed: 0, Skipped: 0, Inconclusive: 0, NotRun: 0
 Processing code coverage result.
+Code Coverage result processed in 96ms.
 Covered 100% / 75%. 36 analyzed Commands in 7 Files.
 ```
 


### PR DESCRIPTION
Fix #461

Stacked on #465, which is stacked on #464. Review those first.

The output blocks were captured on 6.0.0. Three things changed in 6.1.0 and they show up in nearly every block, so a reader diffs their terminal against ours and it does not match. That is worst on the prerequisites page, which exists to make them confident the setup is right.

Every Normal verbosity file line now carries a test count. Real run:

```
[+] .../Planetarium/Private/ConvertTo-AstronomicalUnit.Tests.ps1 183ms (3 tests)
[+] .../Planetarium/Private/Test-PlanetName.Tests.ps1 40ms (4 tests)
[+] .../Planetarium/Public/Get-Planet.Tests.ps1 30ms (5 tests)
[+] .../Planetarium/Public/Get-PlanetDistance.Tests.ps1 25ms (3 tests)
```

Coverage prints a line between the two we showed:

```
Processing code coverage result.
Code Coverage result processed in 96ms.
Covered 100% / 75%. 36 analyzed Commands in 7 Files.
```

The Detailed header is `Pester v6.1.0`, and `Import-Module -PassThru` has an `ExportedCommands` column. I also added a sentence saying a narrow terminal prints that as a list, because it looks nothing like the table and it is the first output anybody compares.

Two claims on the output page while I was there. `TestResult.OutputFormat` has four values and we listed three, `NUnit2.5` was missing. `Output.Verbosity` also accepts `Minimal`, which is silently normalized to `Normal`, so somebody who tries it gets no error and no effect.

## Verification

Counts and strings taken from a real run of the finished tutorial suite on pwsh 7.5.5 with Pester 6.1.0, not transcribed by hand. Site builds.

🤖
